### PR TITLE
add removal procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### master
 - enable overriding default key bindings
 - start using `C-c` to clear screen
+- add uninstall/clean procedure and keybinding (prefix+alt+u) (@chilicuil)
 
 ### v1.2.2, 2015-02-08
 - set GIT_TERMINAL_PROMPT=0 when doing `git clone`, `pull` or `submodule update`

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ You're good to go! The plugin was cloned to `~/.tmux/plugins/` dir and sourced.
 ### Uninstalling plugins
 
 1. remove plugin from `@tpm_plugins` list
-2. All the plugins are installed to `~/.tmux/plugins/`. Find plugin
-  directory there and just remove it.
+2. hit `prefix + alt + u` (I as in *u*install) to remove the plugin
 
 ### Key bindings
 
@@ -58,6 +57,9 @@ You're good to go! The plugin was cloned to `~/.tmux/plugins/` dir and sourced.
 
 `prefix + U`
 - updates plugin(s)
+
+`prefix + alt + u`
+- uninstall unused plugin(s)
 
 ### List of plugins
 

--- a/scripts/clean_plugins.sh
+++ b/scripts/clean_plugins.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/shared_functions.sh"
+
+clean_plugins() {
+	local plugins plugin plugin_directory
+	plugins="$(shared_get_tpm_plugins_list)"
+
+	for plugin_directory in "$SHARED_TPM_PATH"/*; do
+		[ -d "${plugin_directory}" ] || continue
+		plugin="$(shared_plugin_name "${plugin_directory}")"
+		case "${plugins}" in
+			*"${plugin}"*) : ;;
+			*)
+			[ "${plugin}" = "tpm" ] && continue
+			echo_message "Removing \"$plugin\""
+			rm -rf "${plugin_directory}"
+			[ -d "${plugin_directory}" ] &&
+			echo_message "  \"$plugin\" clean fail" ||
+			echo_message "  \"$plugin\" clean success"
+			;;
+		esac
+	done
+}
+
+ensure_tpm_path_exists() {
+	mkdir -p "$SHARED_TPM_PATH"
+}
+
+reload_tmux_environment() {
+	tmux source-file ~/.tmux.conf >/dev/null 2>&1
+}
+
+main() {
+	reload_tmux_environment
+	shared_set_tpm_path_constant
+	ensure_tpm_path_exists
+	clean_plugins
+	reload_tmux_environment
+	end_message
+}
+main

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -5,4 +5,4 @@ update_key_option="@tpm-update"
 default_update_key="U"
 
 clean_key_option="@tpm-clean"
-default_clean_key="Y"
+default_clean_key="M-u"

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -3,3 +3,6 @@ default_install_key="I"
 
 update_key_option="@tpm-update"
 default_update_key="U"
+
+clean_key_option="@tpm-clean"
+default_clean_key="Y"

--- a/tests/expect_successful_clean_plugins
+++ b/tests/expect_successful_clean_plugins
@@ -9,8 +9,8 @@ spawn tmux
 # not work properly.
 sleep 1
 
-# this is tmux prefix + U
-send "Y"
+# this is tmux prefix + alt + u
+send "u"
 
 set timeout 5
 

--- a/tests/expect_successful_clean_plugins
+++ b/tests/expect_successful_clean_plugins
@@ -1,0 +1,30 @@
+#!/usr/bin/env expect
+
+# disables script output
+log_user 0
+
+spawn tmux
+
+# Waiting for tmux to attach. If this is not done, next command, `send` will
+# not work properly.
+sleep 1
+
+# this is tmux prefix + U
+send "Y"
+
+set timeout 5
+
+expect {
+  "Removing \"tmux-example-plugin\"" {
+    expect {
+      "\"tmux-example-plugin\" clean success" {
+        expect { "Done, press ENTER to continue." { exit 0 } }
+        }
+      }
+    }
+
+  timeout {
+    puts "Plugin update prompt timeout";
+    exit 1
+  }
+}

--- a/tests/test_plugin_clean.sh
+++ b/tests/test_plugin_clean.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR"/helpers.sh
+
+manually_install_the_plugin() {
+	rm -rf   ~/.tmux/plugins/
+	mkdir -p ~/.tmux/plugins/
+	cd ~/.tmux/plugins/
+	git clone --quiet https://github.com/tmux-plugins/tmux-example-plugin
+}
+
+test_plugin_installation() {
+	set_tmux_conf_helper <<- HERE
+	run-shell "$PWD/tpm"
+	HERE
+
+	manually_install_the_plugin
+
+	# opens tmux and test it with `expect`
+	"$CURRENT_DIR"/expect_successful_clean_plugins ||
+		fail_helper "Clean fails"
+
+	teardown_helper
+}
+
+main() {
+	test_plugin_installation
+	exit_value_helper
+}
+main

--- a/tpm
+++ b/tpm
@@ -28,12 +28,16 @@ source_plugins() {
 
 # prefix + I - downloads TPM plugins and reloads TMUX environment
 # prefix + U - updates a plugin (or all of them) and reloads TMUX environment
+# prefix + Y - remove unused TPM plugins and reloads TMUX environment
 set_tpm_key_bindings() {
 	local install_key=$(get_tmux_option "$install_key_option" "$default_install_key")
 	tmux bind-key "$install_key" run-shell "$CURRENT_DIR/scripts/install_plugins.sh >/dev/null 2>&1"
 
 	local update_key=$(get_tmux_option "$update_key_option" "$default_update_key")
 	tmux bind-key "$update_key" run-shell "$CURRENT_DIR/scripts/update_plugin_prompt.sh"
+
+	local clean_key=$(get_tmux_option "$clean_key_option" "$default_clean_key")
+	tmux bind-key "$clean_key" run-shell "$CURRENT_DIR/scripts/clean_plugins.sh"
 }
 
 supported_tmux_version_ok() {


### PR DESCRIPTION
Hi,

This pull request adds a clean/remove procedure (attached to prefix + Y) to remove unused plugins.

I though in Y because C and R are used in other plugins (copycat and sensible) and because U and I already are used on this plugin, so I though than YUI would be appropriated even if doesn't stand for anything related to Uninstalling/Cleaning.
