### PR TITLE
add bundle style plugin definition

### DIFF
--- a/tests/test_plugin_bundle_installation.sh
+++ b/tests/test_plugin_bundle_installation.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $CURRENT_DIR/helpers.sh
+
+test_plugin_installation() {
+	set_tmux_conf_helper <<- HERE
+	set -g @bUnDlE "tmux-plugins/tmux-example-plugin"
+	run-shell "$PWD/tpm"
+	HERE
+
+	# opens tmux and test it with `expect`
+	"$CURRENT_DIR"/expect_successful_plugin_download ||
+		fail_helper "Tmux plugin installation fails"
+
+	# check plugin dir exists after download
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-example-plugin/" ||
+		fail_helper "Plugin download fails"
+
+	teardown_helper
+}
+
+main() {
+	test_plugin_installation
+	exit_value_helper
+}
+main


### PR DESCRIPTION
Hi,

This pull request is the first part of https://github.com/tmux-plugins/tpm/pull/30, it adds a bundle syntax sugar to the plugin definition.

```
set -g @tpm_plugins "\
 tmux-plugins/tmux-example-plugin \
 tmux-plugins/other-plugin"
```
```
set -g @bundle "tmux-plugins/tmux-example-plugin"
set -g @bundle "tmux-plugins/other-plugin"
```

The former in my opinion is easier to read and to comment in/out. Tests were added covering the features described.