### PR TITLE
add additional handlers (protocols)

### DIFF
--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -5,32 +5,84 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/shared_functions.sh"
 
 clone() {
-	local plugin=$1
-	cd $SHARED_TPM_PATH &&
+	local plugin; plugin="$1"
+	cd "$SHARED_TPM_PATH" &&
 		GIT_TERMINAL_PROMPT=0 git clone --recursive $plugin
+}
+
+install_plugin_git() {
+	local plugin; plugin="$1"
+	local branch; branch=":${1##*:}"
+	plugin="${1%$branch}"
+	clone "$plugin" ||
+		 clone "git:$plugin"
+	if [ "${branch}" != ":${1}" ]; then #if exists branch/revision
+		(cd "$SHARED_TPM_PATH"/$(shared_plugin_name "$plugin") &&
+		git checkout -q "${branch#:}" 2>&1 >/dev/null)
+	fi
 }
 
 # tries cloning:
 # 1. plugin name directly - works if it's a valid git url
 # 2. expands the plugin name to point to a github repo and tries cloning again
-clone_plugin() {
-	local plugin=$1
+install_plugin_github() {
+	local plugin; plugin="$1"
+	local branch; branch=":${1##*:}"
+	plugin="${1%$branch}"
 	clone "$plugin" ||
 		clone "https://git::@github.com/$plugin"
+	if [ "${branch}" != ":${1}" ]; then #if exists branch/revision
+		(cd "$SHARED_TPM_PATH"/$(shared_plugin_name "$plugin") &&
+		git checkout -q "${branch#:}" 2>&1 >/dev/null)
+	fi
+}
+
+install_plugin_web() {
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
+	(cd "$SHARED_TPM_PATH" && mkdir "${plugin_name}" &&
+	cd "${plugin_name}" && (wget --no-check-certificate "${plugin}" ||
+	curl -k -s -O "${plugin}"))
+}
+
+install_plugin_local() {
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
+	(cd "$SHARED_TPM_PATH" && mkdir "${plugin_name}" &&
+	cd "${plugin_name}" && cp -r "${plugin}" .)
 }
 
 # pull new changes or clone plugin
 install_plugin() {
-	local plugin="$1"
-	local plugin_name="$(shared_plugin_name "$plugin")"
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
 
 	if plugin_already_installed "$plugin"; then
 		# plugin is already installed
 		echo_message "Already installed \"$plugin_name\""
 	else
-		# plugin wasn't cloned so far - clone it
 		echo_message "Installing \"$plugin_name\""
-		clone_plugin "$plugin" &&
+		local handler; handler="${1%%:*}:"
+		plugin="${1#$handler}"
+
+		case "${handler}" in
+			''|*/*) case "${1}" in
+					/*|~*|\$*)	install_plugin_local  "${1}" ;;
+					*)		install_plugin_github "${1}" ;;
+				esac ;;
+			gh*|github*|git@github.com*)	install_plugin_github "${plugin}" ;;
+			git:)				install_plugin_git "${plugin}" ;;
+			file:)				install_plugin_local "${plugin#//}" ;;
+			http:|ftp:)			install_plugin_web "${1}" ;;
+			https:)
+				case "${1}" in
+					*github.com/*) install_plugin_github "${plugin#//github.com/}";;
+					*) install_plugin_web "${1}";;
+				esac ;;
+			*) set_false ;;
+		 esac
+
+		 [ X"${?}" = X"0" ] &&
 			echo_message "  \"$plugin_name\" download success" ||
 			echo_message "  \"$plugin_name\" download fail"
 	fi

--- a/scripts/shared_functions.sh
+++ b/scripts/shared_functions.sh
@@ -16,15 +16,31 @@ shared_get_tpm_plugins_list() {
 }
 
 # Allowed plugin name formats:
-# 1. "git://github.com/user/plugin_name.git"
-# 2. "user/plugin_name"
+# 1.  "user/plugin_name"
+# 2.  "user/plugin_name:branch"
+# 3.  "gh:user/plugin_name"
+# 4.  "gh:user/plugin_name:branch"
+# 5.  "github:user/plugin_name"
+# 6.  "github:user/plugin_name:branch"
+# 7.  "http://github.com/user/plugin_name"
+# 8.  "https://github.com/user/plugin_name:branch"
+# 9.  "git://github.com/user/plugin_name.git"
+# 10. "git://github.com/user/plugin_name.git:branch"
+# 11. "git://domain.tld/plugin_name"
+# 12. "git://domain.tld/plugin_name:branch"
+# 13. "http://domain.tld/plugin_name"
+# 14. "https://domain.tld/plugin_name"
+# 15. "ftp://domain.tld/plugin_name"
+# 16. "file://local/path/plugin_name"
 shared_plugin_name() {
-	local plugin="$1"
-	# get only the part after the last slash, e.g. "plugin_name.git"
-	local plugin_basename="$(basename "$plugin")"
+	local plugin; plugin="$1"
+	# get only the part after the last slash, e.g. "plugin_name.git:branch"
+	local plugin_basename; plugin_basename="$(basename "$plugin")"
+	# remove branch (if it exists) to get only "plugin_name.git"
+	local plugin_name; plugin_name="${plugin_basename%:*}"
 	# remove ".git" extension (if it exists) to get only "plugin_name"
-	local plugin_name="${plugin_basename%.git}"
-	echo "$plugin_name"
+	plugin_name="${plugin_name%.git}"
+	printf "%s\\n" "$plugin_name"
 }
 
 shared_plugin_path() {
@@ -47,8 +63,8 @@ reload_tmux_environment() {
 plugin_already_installed() {
 	local plugin="$1"
 	local plugin_path="$(shared_plugin_path "$plugin")"
-	cd "$plugin_path" &&
-		git remote >/dev/null 2>&1
+	cd "$plugin_path" #&& unmarry from git
+		#git remote >/dev/null 2>&1
 }
 
 end_message() {
@@ -56,6 +72,11 @@ end_message() {
 	echo_message "TMUX environment reloaded."
 	echo_message ""
 	echo_message "Done, press ENTER to continue."
+}
+
+set_false()
+{
+	return 1
 }
 
 # Ensures a message is displayed for 5 seconds in tmux prompt.

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -16,36 +16,78 @@ cancel() {
 	exit 0
 }
 
-pull_changes() {
-	local plugin="$1"
-	local plugin_path=$(shared_plugin_path "$plugin")
-	cd $plugin_path &&
-		GIT_TERMINAL_PROMPT=0 git pull &&
-		GIT_TERMINAL_PROMPT=0 git submodule update --init --recursive
+update_plugin_git() {
+	local plugin; plugin="$1"
+	local branch; branch=":${1##*:}"
+	local plugin_path; plugin_path=$(shared_plugin_path "$plugin")
+	plugin="${1%$branch}"
+	#update only makes sense when no specific branch/revision is set
+	if [ "${branch}" = ":${1}" ]; then
+		 cd "$plugin_path" &&
+			  GIT_TERMINAL_PROMPT="0" git pull &&
+			  GIT_TERMINAL_PROMPT="0" git submodule update --init --recursive
+	fi
+}
+
+update_plugin_web() {
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
+	local plugin_path; plugin_path=$(shared_plugin_path "$plugin")
+	(cd "$plugin_path" && rm -rf "${plugin_name}" &&
+	(wget --no-check-certificate "${plugin}" || curl -k -s -O "${plugin}"))
+}
+
+update_plugin_local() {
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
+	local plugin_path; plugin_path=$(shared_plugin_path "$plugin")
+	cd "$plugin_path" && rm -rf "${plugin_name}" && cp -r "${plugin}" .
 }
 
 update() {
-	local plugin="$1"
-	echo_message "Updating \"$plugin\""
-	$(pull_changes "$plugin" > /dev/null 2>&1) &&
-		echo_message "  \"$plugin\" update success" ||
-		echo_message "  \"$plugin\" update fail"
+	local plugin; plugin="$1"
+	local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
+	echo_message "Updating \"$plugin_name\""
+
+	local handler; handler="${1%%:*}:"
+	plugin="${1#$handler}"
+
+	case "${handler}" in
+		''|*/*) case "${1}" in
+			/*|~*|\$*)	update_plugin_local "${1}" ;;
+			*)		update_plugin_git   "${1}" ;;
+			esac ;;
+		gh*|github*|git@github.com*)	update_plugin_git   "${plugin}" ;;
+		git:)				update_plugin_git   "${plugin}" ;;
+		file:)				update_plugin_local "${plugin#//}" ;;
+		http:|ftp:)			update_plugin_web   "${1}" ;;
+		https:)
+			case "${1}" in
+				*github.com/*) update_plugin_git "${plugin#//github.com/}";;
+				*) update_plugin_web "${1}";;
+			esac ;;
+		*) set_false ;;
+	esac
+
+	[ "${?}" = "0" ] &&
+		 echo_message "  \"$plugin_name\" update success" ||
+		 echo_message "  \"$plugin_name\" update fail"
 }
 
 
 update_all() {
-	local plugins="$(shared_get_tpm_plugins_list)"
+	local plugins plugin; plugins="$(shared_get_tpm_plugins_list)"
 	for plugin in $plugins; do
-		local plugin_name="$(shared_plugin_name "$plugin")"
+		local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
 		# updating only installed plugins
 		if plugin_already_installed "$plugin_name"; then
-			update "$plugin_name"
+			update "$plugin"
 		fi
 	done
 }
 
 handle_plugin_update() {
-	local arg="$1"
+	local arg; arg="$1"
 
 	if empty "$arg"; then
 		cancel
@@ -65,7 +107,7 @@ handle_plugin_update() {
 }
 
 main() {
-	local arg="$1"
+	local arg; arg="$1"
 	shared_set_tpm_path_constant
 	handle_plugin_update "$arg"
 	reload_tmux_environment

--- a/scripts/update_plugin_prompt.sh
+++ b/scripts/update_plugin_prompt.sh
@@ -9,14 +9,14 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/shared_functions.sh"
 
 display_plugin_update_list() {
-	local plugins="$(shared_get_tpm_plugins_list)"
+	local plugins plugin; plugins="$(shared_get_tpm_plugins_list)"
 	echo_message "Installed plugins:"
 	echo_message ""
 
 	for plugin in $plugins; do
 		# displaying only installed plugins
 		if plugin_already_installed "$plugin"; then
-			local plugin_name="$(shared_plugin_name "$plugin")"
+			local plugin_name; plugin_name="$(shared_plugin_name "$plugin")"
 			echo_message "  $plugin_name"
 		fi
 	done

--- a/tests/expect_successful_plugin_download_extended
+++ b/tests/expect_successful_plugin_download_extended
@@ -1,0 +1,92 @@
+#!/usr/bin/env expect
+
+# disables script output
+log_user 0
+
+spawn tmux
+
+# Waiting for tmux to attach. If this is not done, next command, `send` will
+# not work properly.
+sleep 1
+
+# this is tmux prefix + I
+send "I"
+
+# cloning might take a while
+set timeout 15
+
+expect {
+  "Installing \"tmux-example-plugin\"" {
+expect {
+  "\"tmux-example-plugin\" download success" {
+expect {
+  "Installing \"tmux-online-status\"" {
+expect {
+  "\"tmux-online-status\" download success" {
+expect {
+  "Installing \"tmux-battery\"" {
+expect {
+  "\"tmux-battery\" download success" {
+expect {
+  "Installing \"tmux-sidebar\"" {
+expect {
+  "\"tmux-sidebar\" download success" {
+expect {
+  "Installing \"tmux-sensible\"" {
+expect {
+  "\"tmux-sensible\" download success" {
+expect {
+  "Installing \"sha1sum.txt\"" {
+expect {
+  "\"sha1sum.txt\" download success" {
+expect {
+  "Installing \"meta-micro\"" {
+expect {
+  "\"meta-micro\" download success" {
+expect {
+  "Installing \"readme.txt\"" {
+expect {
+  "\"readme.txt\" download success" {
+expect {
+  "Installing \"run-tests-within-vm\"" {
+expect {
+  "\"run-tests-within-vm\" download success" {
+    expect { "Done, press ENTER to continue" {
+        send ""
+    }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+
+  timeout {
+    puts "Plugin installation timeout (1)";
+    exit 1
+  }
+}
+
+# this is tmux prefix + I
+send "I"
+
+expect {
+  "Already installed \"tmux-example-plugin\"" {
+expect {
+  "Already installed \"tmux-online-status\"" {
+expect {
+  "Already installed \"tmux-battery\"" {
+expect {
+  "Already installed \"tmux-sidebar\"" {
+expect {
+  "Already installed \"tmux-sensible\"" {
+expect {
+  "Already installed \"sha1sum.txt\"" {
+expect {
+  "Already installed \"meta-micro\"" {
+expect {
+  "Already installed \"readme.txt\"" {
+expect {
+  "Already installed \"run-tests-within-vm\"" {
+    expect { "Done, press ENTER to continue" { exit 0
+    }}}}}}}}}}}}}}}}}}}
+
+  timeout {
+    puts "Plugin installation timeout (2)";
+    exit 1
+  }
+}

--- a/tests/expect_successful_update_of_all_plugins_extended
+++ b/tests/expect_successful_update_of_all_plugins_extended
@@ -1,0 +1,91 @@
+#!/usr/bin/env expect
+
+# disables script output
+log_user 0
+
+spawn tmux
+
+# Waiting for tmux to attach. If this is not done, next command, `send` will
+# not work properly.
+sleep 1
+
+# this is tmux prefix + U
+send "U"
+
+set timeout 15
+
+expect {
+    "Installed plugins" {
+expect {
+    "\"tmux-example-plugin\"" {
+expect {
+    "\"tmux-online-status\"" {
+expect {
+    "\"tmux-battery\"" {
+expect {
+    "\"tmux-sidebar\"" {
+expect {
+    "\"tmux-sensible\"" {
+expect {
+    "\"sha1sum.txt\"" {
+expect {
+    "\"meta-micro\"" {
+expect {
+    "\"readme.txt\"" {
+expect {
+    "\"run-tests-within-vm\"" {
+expect {
+    "\"all\" - updates all plugins" {
+    expect { "ENTER - cancels" }
+          }}}}}}}}}}}}}}}}}}}}}
+
+  timeout {
+    puts "Plugin update prompt timeout";
+    exit 1
+  }
+}
+
+send "all\r"
+
+expect {
+    "Updating all plugins!" {
+expect {
+    "Updating \"tmux-example-plugin\"" {
+expect {
+    "\"tmux-example-plugin\" update success" {
+expect {
+    "Updating \"tmux-online-status\"" {
+expect {
+    "\"tmux-online-status\" update success" {
+expect {
+    "Updating \"tmux-battery\"" {
+expect {
+    "\"tmux-battery\" update success" {
+expect {
+    "Updating \"tmux-sidebar\"" {
+expect {
+    "\"tmux-sidebar\" update success" {
+expect {
+    "Updating \"sha1sum.txt\"" {
+expect {
+    "\"sha1sum.txt\" update success" {
+expect {
+    "Updating \"meta-micro\"" {
+expect {
+    "\"meta-micro\" update success" {
+expect {
+    "Updating \"readme.txt\"" {
+expect {
+    "\"readme.txt\" update success" {
+expect {
+    "Updating \"run-tests-within-vm\"" {
+expect {
+    "\"run-tests-within-vm\" update success" {
+    expect { "Done, press ENTER to continue." { exit 0 } }
+          }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+
+  timeout {
+    puts "Update all plugins timeout";
+    exit 1
+  }
+}

--- a/tests/test_plugin_installation_extended.sh
+++ b/tests/test_plugin_installation_extended.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR"/helpers.sh
+
+test_plugin_installation() {
+	set_tmux_conf_helper <<- HERE
+	set -g @tpm_plugins " \
+	tmux-plugins/tmux-example-plugin \
+	gh:tmux-plugins/tmux-online-status \
+	github:tmux-plugins/tmux-battery \
+	github:tmux-plugins/tmux-sidebar:master \
+	https://github.com/tmux-plugins/tmux-sensible:3ea5b \
+	http://ovh.net/files/sha1sum.txt \
+	git://git.openembedded.org/meta-micro \
+	ftp://ftp.microsoft.com/developr/readme.txt \
+	file://$PWD/tests/run-tests-within-vm"
+	run-shell "$PWD/tpm"
+	HERE
+
+        #tmux; exit 0
+	# opens tmux and test it with `expect`
+	"$CURRENT_DIR"/expect_successful_plugin_download_extended ||
+		 fail_helper "Tmux plugin installation fails"
+
+	# check plugin dir exists after download
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-example-plugin/" ||
+		 fail_helper "Plugin tmux-plugins/tmux-example-plugin download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-online-status/" ||
+		 fail_helper "Plugin gh:tmux-plugins/tmux-online-status download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-battery/" ||
+		 fail_helper "Plugin github:tmux-plugins/tmux-battery download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-sidebar/" ||
+		 fail_helper "Plugin github:tmux-plugins/tmux-sidebar:master download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/tmux-sensible/" ||
+		 fail_helper "Plugin https://github.com/tmux-plugins/tmux-sensible:3ea5b download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/sha1sum.txt/" ||
+		 fail_helper "Plugin http://ovh.net/files/sha1sum.txt download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/meta-micro/" ||
+		 fail_helper "Plugin git://git.openembedded.org/meta-micro download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/readme.txt/" ||
+		 fail_helper "Plugin ftp://ftp.microsoft.com/developr/readme.txt download failed"
+
+	check_dir_exists_helper "$HOME/.tmux/plugins/run-tests-within-vm/" ||
+		 fail_helper "Plugin file://$PWD/tests/run-tests-within-vm failed"
+
+	teardown_helper
+}
+
+main() {
+	test_plugin_installation
+	exit_value_helper
+}
+main

--- a/tests/test_plugin_update_extended.sh
+++ b/tests/test_plugin_update_extended.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR"/helpers.sh
+
+test_plugin_installation() {
+	set_tmux_conf_helper <<- HERE
+	set -g @tpm_plugins " \
+	tmux-plugins/tmux-example-plugin \
+	gh:tmux-plugins/tmux-online-status \
+	github:tmux-plugins/tmux-battery \
+	github:tmux-plugins/tmux-sidebar:master \
+	https://github.com/tmux-plugins/tmux-sensible:3ea5b \
+	http://ovh.net/files/sha1sum.txt \
+	git://git.openembedded.org/meta-micro \
+	ftp://ftp.microsoft.com/developr/readme.txt \
+	file://$PWD/tests/run-tests-within-vm"
+	run-shell "$PWD/tpm"
+	HERE
+
+	# opens tmux and install plugins, test results with `expect`
+	"$CURRENT_DIR"/expect_successful_plugin_download_extended ||
+		fail_helper "Tmux plugin installation phase in update fails"
+
+	# opens tmux and update plugins, test results with `expect`
+	"$CURRENT_DIR"/expect_successful_update_of_all_plugins ||
+		fail_helper "Tmux 'update all plugins' fails"
+
+	teardown_helper
+}
+
+main() {
+	test_plugin_installation
+	exit_value_helper
+}
+main


### PR DESCRIPTION
Hi,

This pull request is the second part part of #30, it adds additional protocols from which tpm can fetch plugins.

```
	set -g @tpm_plugins " \
	tmux-plugins/tmux-example-plugin \
	gh:tmux-plugins/tmux-online-status \
	github:tmux-plugins/tmux-battery \
	github:tmux-plugins/tmux-sidebar:master \
	https://github.com/tmux-plugins/tmux-sensible:3ea5b \
	http://ovh.net/files/sha1sum.txt \
	git://git.openembedded.org/meta-micro \
	ftp://ftp.microsoft.com/developr/readme.txt \
	file://$PWD/tests/run-tests-within-vm"
```
Tests were added covering the features described.
