### PR TITLE
Check write permissions to plugin folder

### DIFF
--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -47,10 +47,17 @@ ensure_tpm_path_exists() {
 	mkdir -p $SHARED_TPM_PATH
 }
 
+verify_tpm_path_permissions() {
+	# check the write permission flag for all users to ensure
+	# that we have proper access
+	[ -w $SHARED_TPM_PATH ] || echo_message "$SHARED_TPM_PATH does not seem to be writable!"
+}
+
 main() {
 	reload_tmux_environment
 	shared_set_tpm_path_constant
 	ensure_tpm_path_exists
+	verify_tpm_path_permissions
 	install_plugins
 	reload_tmux_environment
 	end_message


### PR DESCRIPTION
Check if required write permissions to write folder are in place; if
the `stat` sanity check fails, warn the user.
Somewhat solves Github issue #20 by warning the user.