### PR TITLE
Replaced "ENTER" with "q" in echo_message text. Fixes tmux-plugins/tpm#43

### DIFF
--- a/scripts/shared_functions.sh
+++ b/scripts/shared_functions.sh
@@ -65,7 +65,7 @@ end_message() {
 	echo_message ""
 	echo_message "TMUX environment reloaded."
 	echo_message ""
-	echo_message "Done, press ENTER to continue."
+	echo_message "Done, press \"q\" to continue."
 }
 
 # Ensures a message is displayed for 5 seconds in tmux prompt.

--- a/scripts/update_plugin_prompt.sh
+++ b/scripts/update_plugin_prompt.sh
@@ -25,7 +25,7 @@ display_plugin_update_list() {
 	echo_message "Type plugin name to update it."
 	echo_message ""
 	echo_message "- \"all\" - updates all plugins"
-	echo_message "- ENTER - cancels"
+	echo_message "- \"q\" - cancels"
 }
 
 update_plugin_prompt() {


### PR DESCRIPTION
This is just a text change; `[ENTER]` doesn't work on these prompts; `q` or ^c does.

Tested on tmux 2.0