### PR TITLE
Replaced "ENTER" w/"q" in echo_message text&tests. Fixes tmux-plugins/tpm#43

### DIFF
--- a/scripts/shared_functions.sh
+++ b/scripts/shared_functions.sh
@@ -65,7 +65,7 @@ end_message() {
 	echo_message ""
 	echo_message "TMUX environment reloaded."
 	echo_message ""
-	echo_message "Done, press ENTER to continue."
+	echo_message "Done, press \"q\" to continue."
 }
 
 # Ensures a message is displayed for 5 seconds in tmux prompt.

--- a/scripts/update_plugin_prompt.sh
+++ b/scripts/update_plugin_prompt.sh
@@ -25,7 +25,7 @@ display_plugin_update_list() {
 	echo_message "Type plugin name to update it."
 	echo_message ""
 	echo_message "- \"all\" - updates all plugins"
-	echo_message "- ENTER - cancels"
+	echo_message "- \"q\" - cancels"
 }
 
 update_plugin_prompt() {

--- a/tests/expect_successful_clean_plugins
+++ b/tests/expect_successful_clean_plugins
@@ -18,7 +18,7 @@ expect {
   "Removing \"tmux-example-plugin\"" {
     expect {
       "\"tmux-example-plugin\" clean success" {
-        expect { "Done, press ENTER to continue." { exit 0 } }
+        expect { "Done, press \"q\" to continue." { exit 0 } }
         }
       }
     }

--- a/tests/expect_successful_multiple_plugins_download
+++ b/tests/expect_successful_multiple_plugins_download
@@ -23,10 +23,10 @@ expect { "Installing \"tmux-example-plugin\"" {
 
       expect { "\"tmux-copycat\" download success" {
 
-        expect { "Done, press ENTER to continue" {
+        expect { "Done, press \"q\" to continue" {
             send ""
           }
-        } # Done, press ENTER to continue
+        } # Done, press \"q\" to continue
 
         }
       } # "tmux-copycat" download success

--- a/tests/expect_successful_plugin_download
+++ b/tests/expect_successful_plugin_download
@@ -21,7 +21,7 @@ expect {
     expect {
       "\"tmux-example-plugin\" download success" {
 
-        expect { "Done, press ENTER to continue" {
+        expect { "Done, press \"q\" to continue" {
             send ""
           }
         }
@@ -43,7 +43,7 @@ send "I"
 expect {
   "Already installed \"tmux-example-plugin\"" {
 
-    expect { "Done, press ENTER to continue" { exit 0 } }
+    expect { "Done, press \"q\" to continue" { exit 0 } }
 
   }
 

--- a/tests/expect_successful_update_of_a_single_plugin
+++ b/tests/expect_successful_update_of_a_single_plugin
@@ -23,7 +23,7 @@ expect {
         expect {
           "\"all\" - updates all plugins" {
 
-            expect { "ENTER - cancels" }
+            expect { "\q\" - cancels" }
 
           }
         }
@@ -47,7 +47,7 @@ expect {
     expect {
       "\"tmux-example-plugin\" update success" {
 
-        expect { "Done, press ENTER to continue." { exit 0 } }
+        expect { "Done, press \"q\" to continue." { exit 0 } }
 
       }
     }

--- a/tests/expect_successful_update_of_all_plugins
+++ b/tests/expect_successful_update_of_all_plugins
@@ -23,7 +23,7 @@ expect {
         expect {
           "\"all\" - updates all plugins" {
 
-            expect { "ENTER - cancels" }
+            expect { "\"q\" - cancels" }
 
           }
         }
@@ -50,7 +50,7 @@ expect {
         expect {
           "\"tmux-example-plugin\" update success" {
 
-            expect { "Done, press ENTER to continue." { exit 0 } }
+            expect { "Done, press \"q\" to continue." { exit 0 } }
 
           }
         }


### PR DESCRIPTION
**ENTER** doesn't work in this context, only ^c and **q**.  I've updated the text (and the expect statements in the tests) to reflect this.