### PR TITLE
match 'set-option -g @plugin' and 'set -g @plugin' both

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -43,7 +43,7 @@ tpm_plugins_list_helper() {
 
 	# read set -g @plugin "tmux-plugins/tmux-example-plugin" entries
 	_tmux_conf_contents "full" |
-		awk '/^ *set +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $4 }'
+		awk '/^ *set(-option)? +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $4 }'
 }
 
 # Allowed plugin name formats:


### PR DESCRIPTION
In my tmux.conf, I use `set-option -g @plugin`, but in this way no plugins will be loaded.

I checked `scripts/helpers/plugin_functions.sh`, find the script only match 'set -g @plugin', so I make it match 'set -g @plugin' and 'set-option -g @plugin' both.