### PR TITLE
Fixed enviorment variables support for path expansion

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -5,7 +5,7 @@ tpm_plugins_variable_name="@tpm_plugins"
 _manual_expansion() {
 	local path="$1"
 	local expanded_tilde="${path/#\~/$HOME}"
-	echo "${expanded_tilde/#\$HOME/$HOME}"
+	echo $(echo $expanded_tilde | envsubst)
 }
 
 _tpm_path() {


### PR DESCRIPTION
Hi,

I have abit complex environment, and my tmux config (tmux.conf) is something like "source-file ${TMUX_CONFIG}"
however, tpm did not expand it well.

I Fixed this issue by fixing path expansion to not only handle ${HOME} but to do full environment substitution.

Hope you like the solution :)