### PR TITLE
Fix automatic tpm installation command in doc

### DIFF
--- a/docs/automatic_tpm_installation.md
+++ b/docs/automatic_tpm_installation.md
@@ -6,7 +6,9 @@ If you want to install `tpm` and plugins automatically when tmux is started, put
 
 ```
 if "test ! -d ~/.tmux/plugins/tpm" \
-   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm'; \
+    set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.tmux/plugins/'; \
+    run '~/.tmux/plugins/tpm/bin/install_plugins'"
 ```
 
 This useful tip was submitted by @acr4 and narfman0.


### PR DESCRIPTION
To install plugins in tmux.conf, TMUX_PLUGIN_MANAGER_PATH must be configured.

I checkd old script doesn't work in tmux 2.0 and 2.3, and new script ( with TMUX_PLUGIN_MANAGER_PATH ) works fine in 2.0 and 2.3.

This is a temporary solution, but I couldn't find true solution.

## long description

Execution of "~/.tmux/plugins/tpm/bin/install_plugins" succeed before tmux command ( = outside of tmux ) and after tmux command ( inside of tmux ), BUT it doesn't succeed in initializing of tmux ( = .tmux.conf ).

## Why fail in .tmux.conf ?

1. `install_plugins` requires `TMUX_PLUGIN_MANAGER_PATH` environment variable.
2. `TMUX_PLUGIN_MANAGER_PATH` is normally configured in [here1](https://github.com/bigwheel/tpm/blob/79d90f9/tpm#L25) inside of [here2](https://github.com/tmux-plugins/tpm/blob/1579534/scripts/helpers/plugin_functions.sh#L12).
3. [here2](https://github.com/tmux-plugins/tpm/blob/1579534/scripts/helpers/plugin_functions.sh#L12) needs completely started tmux server ( = tpm loaded, it configures `TMUX_PLUGIN_MANAGER_PATH` variable ), however if and only if `install_plugins` is executed in initializing of tmux, it cannot be accomplished.
Because tmux server already exists and it doesn't started completely.


This is so situation specific problem, then I cannot concieve clear solution.
If there is more better solution, dismiss this pull request please.