### PR TITLE
Add ability to use branches for plugins

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -56,7 +56,7 @@ tpm_plugins_list_helper() {
 
 	# read set -g @plugin "tmux-plugins/tmux-example-plugin" entries
 	_tmux_conf_contents "full" |
-		awk '/^[ \t]*set(-option)? +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $4 }'
+		awk '/^[ \t]*set(-option)? +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); gsub(/#/, " "); print $4","$5 }'
 }
 
 # Allowed plugin name formats:


### PR DESCRIPTION
This PR allows specifying a github plugin with a specific branch to use on checkout. If nothing is specified, it works as is and it is backwards compatible.