### PR TITLE
Improve `sourced_files` method.

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -27,8 +27,12 @@ _tmux_conf_contents() {
 
 # return files sourced from tmux config files
 _sourced_files() {
-	_tmux_conf_contents |
-		awk '/^[ \t]*source(-file)? +/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $2 }'
+	for f in $(_tmux_conf_contents |
+		grep "tmux source .*" -v |
+		grep "source .*" -o |
+		awk '/^[ \t]*source(-file)? +/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $2 }'); do
+			eval ls $f;  # eval is required as there could be `source *.conf` to exapnd globs
+	done
 }
 
 # Want to be able to abort in certain cases


### PR DESCRIPTION
There are several issues with this method, such as #141, #112 probably
some others, which says there are problem installing plugins.
The problme is that `sourced_files` method doesn't always correctly
identifies sources files, so plugin settings defined in those
configuration files would not be loaded.

This change fixes this by doing next things:

  * excluding `tmux source` command, which could present in config
  * greping all `source` lines
  * awk command is left original
  * using `eval`, so that globed files `source *.conf` would be loaded
    as well

Probably the fix is not perfect, so I'm open to any suggestions and improvements.