### PR TITLE
Flexible TMux Configuration Load

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -20,15 +20,11 @@ _CACHED_TPM_PATH="$(_tpm_path)"
 #
 _get_user_tmux_conf() {
 	# Define the different possible locations.
-	custom_location="$TMUX_PLUGIN_MANAGER_CONFIG_LOCATION"
 	xdg_location="$XDG_CONFIG_HOME/tmux/tmux.conf"
 	default_location="$HOME/.tmux.conf"
 
 	# Search for the correct configuration file by priority.
-	if [ -n "$custom_location" ]; then
-		echo "$custom_location"
-
-	elif [ -f "$xdg_location" ]; then
+	if [ -f "$xdg_location" ]; then
 		echo "$xdg_location"
 
 	else

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -15,8 +15,30 @@ _tpm_path() {
 
 _CACHED_TPM_PATH="$(_tpm_path)"
 
+# Get the absolute path to the users configuration file of TMux.
+# This includes a prioritized search on different locations.
+#
+_get_user_tmux_conf() {
+  # Define the different possible locations.
+  custom_location="$TMUX_PLUGIN_MANAGER_CONFIG_LOCATION"
+  xdg_location="$XDG_CONFIG_HOME/tmux/tmux.conf"
+  default_location="$HOME/.tmux.conf"
+
+  # Search for the correct configuration file by priority.
+  if [ -n "$custom_location" ]; then
+    echo "$custom_location"
+
+  elif [ -f "$xdg_location" ]; then
+    echo "$xdg_location"
+
+  else
+    echo "$default_location"
+  fi
+}
+
 _tmux_conf_contents() {
-	cat /etc/tmux.conf ~/.tmux.conf 2>/dev/null
+  user_config=$(_get_user_tmux_conf)
+	cat /etc/tmux.conf "$user_config" 2>/dev/null
 	if [ "$1" == "full" ]; then # also output content from sourced files
 		local file
 		for file in $(_sourced_files); do

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -19,25 +19,25 @@ _CACHED_TPM_PATH="$(_tpm_path)"
 # This includes a prioritized search on different locations.
 #
 _get_user_tmux_conf() {
-  # Define the different possible locations.
-  custom_location="$TMUX_PLUGIN_MANAGER_CONFIG_LOCATION"
-  xdg_location="$XDG_CONFIG_HOME/tmux/tmux.conf"
-  default_location="$HOME/.tmux.conf"
+	# Define the different possible locations.
+	custom_location="$TMUX_PLUGIN_MANAGER_CONFIG_LOCATION"
+	xdg_location="$XDG_CONFIG_HOME/tmux/tmux.conf"
+	default_location="$HOME/.tmux.conf"
 
-  # Search for the correct configuration file by priority.
-  if [ -n "$custom_location" ]; then
-    echo "$custom_location"
+	# Search for the correct configuration file by priority.
+	if [ -n "$custom_location" ]; then
+		echo "$custom_location"
 
-  elif [ -f "$xdg_location" ]; then
-    echo "$xdg_location"
+	elif [ -f "$xdg_location" ]; then
+		echo "$xdg_location"
 
-  else
-    echo "$default_location"
-  fi
+	else
+		echo "$default_location"
+	fi
 }
 
 _tmux_conf_contents() {
-  user_config=$(_get_user_tmux_conf)
+	user_config=$(_get_user_tmux_conf)
 	cat /etc/tmux.conf "$user_config" 2>/dev/null
 	if [ "$1" == "full" ]; then # also output content from sourced files
 		local file


### PR DESCRIPTION
The current implementation is hard-coded about where to get the _TMux_ configuration file for read in the listed plugins.
But _TMux_ could be started with a different configuration file. Following the [XDG Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for _TMux_ as also suggested in the [ArchWiki](https://www.linuxsecrets.com/archlinux-wiki/wiki.archlinux.org/index.php/XDG_Base_Directory_support.html#Partial), the default location does not fit anymore. In that case the plugin manager is unusable.
To provide a more configurable solution, I've added a new function to search for the _TMux_ configuration in prioritized order.
- First I've defined the optional environment variable `TMUX_PLUGIN_MANAGER_CONFIG_LOCATION`, which has the highest priority and can be set by the user to anything, regardless if it exists or not.
- On second place the `XDG_CONFIG_HOME` directory is searched for an _TMux_ entry.
- At least the default one at `$HOME/.tmux.conf` is taken.

The implementation is super simple, but allows user like me to be more flexible.