### PR TITLE
Update README.md installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 # set -g @plugin 'git@bitbucket.com/user/plugin'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+run -b '~/.tmux/plugins/tpm/tpm'
 ```
 
 Reload TMUX environment so TPM is sourced:


### PR DESCRIPTION
`run '~/.tmux/plugins/tpm/tpm'` should be run in the background, so the `-b` flag was added. This addition also solved a mysterious crash-on-start issue I was experiencing.