### PR TITLE
Add branch support for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # Other examples:
 # set -g @plugin 'github_username/plugin_name'
+# set -g @plugin 'github_username/plugin_name#branch'
 # set -g @plugin 'git@github.com/user/plugin'
 # set -g @plugin 'git@bitbucket.com/user/plugin'
 

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -15,7 +15,7 @@ fi
 clone() {
 	local plugin="$1"
 	cd "$(tpm_path)" &&
-		GIT_TERMINAL_PROMPT=0 git clone --recursive "$plugin" >/dev/null 2>&1
+		GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
 }
 
 # tries cloning:
@@ -23,20 +23,22 @@ clone() {
 # 2. expands the plugin name to point to a github repo and tries cloning again
 clone_plugin() {
 	local plugin="$1"
-	clone "$plugin" ||
-		clone "https://git::@github.com/$plugin"
+	local branch="$2"
+	clone "$plugin" "$branch" ||
+		clone "https://git::@github.com/$plugin" "$branch"
 }
 
 # clone plugin and produce output
 install_plugin() {
 	local plugin="$1"
+	local branch=`[ -z "$2" ] && echo "master" || echo "$2"`
 	local plugin_name="$(plugin_name_helper "$plugin")"
 
 	if plugin_already_installed "$plugin"; then
 		echo_ok "Already installed \"$plugin_name\""
 	else
 		echo_ok "Installing \"$plugin_name\""
-		clone_plugin "$plugin" &&
+		clone_plugin "$plugin" "$branch" &&
 			echo_ok "  \"$plugin_name\" download success" ||
 			echo_err "  \"$plugin_name\" download fail"
 	fi
@@ -45,7 +47,8 @@ install_plugin() {
 install_plugins() {
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
-		install_plugin "$plugin"
+		IFS='#' read -ra plugin <<< "$plugin"
+		install_plugin "${plugin[0]}" "${plugin[1]}"
 	done
 }
 

--- a/scripts/source_plugins.sh
+++ b/scripts/source_plugins.sh
@@ -30,7 +30,8 @@ source_plugins() {
 	local plugin plugin_path
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
-		plugin_path="$(plugin_path_helper "$plugin")"
+		IFS='#' read -ra plugin <<< "$plugin"
+		plugin_path="$(plugin_path_helper "${plugin[0]}")"
 		silently_source_all_tmux_files "$plugin_path"
 	done
 }

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -37,7 +37,8 @@ update_all() {
 	echo_ok ""
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
-		local plugin_name="$(plugin_name_helper "$plugin")"
+		IFS='#' read -ra plugin <<< "$plugin"
+		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
 		# updating only installed plugins
 		if plugin_already_installed "$plugin_name"; then
 			update "$plugin_name" &
@@ -49,7 +50,8 @@ update_all() {
 update_plugins() {
 	local plugins="$*"
 	for plugin in $plugins; do
-		local plugin_name="$(plugin_name_helper "$plugin")"
+		IFS='#' read -ra plugin <<< "$plugin"
+		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
 		if plugin_already_installed "$plugin_name"; then
 			update "$plugin_name" &
 		else


### PR DESCRIPTION
Allows to specify branch for plugins by using `set -g @plugin 'repo#branch'`. If branch is not specified master will be used. 