### PR TITLE
Default value for XDG_CONFIG_HOME

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -20,7 +20,7 @@ _CACHED_TPM_PATH="$(_tpm_path)"
 #
 _get_user_tmux_conf() {
 	# Define the different possible locations.
-	xdg_location="$XDG_CONFIG_HOME/tmux/tmux.conf"
+	xdg_location="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
 	default_location="$HOME/.tmux.conf"
 
 	# Search for the correct configuration file by priority.


### PR DESCRIPTION
According to [the specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), `$XDG_CONFIG_HOME` should have a default value of `$HOME/.config`.

This might cause breakage for users who created a `$HOME/.config/tmux/tmux.conf` file but forgot and ended up still using `$HOME/.tmux.conf`, I don't expect it's that many as it doesn't really make sense.