### PR TITLE
fix_reload_twice_issue while "Install" , "Undate" , "Clean" plugins using binding keys

### DIFF
--- a/bindings/clean_plugins
+++ b/bindings/clean_plugins
@@ -11,7 +11,7 @@ source "$HELPERS_DIR/tmux_echo_functions.sh"
 source "$HELPERS_DIR/tmux_utils.sh"
 
 main() {
-	reload_tmux_environment
+	#reload_tmux_environment #This will cause tmux source-file ~/.tmux.conf twice and almost the same time
 	"$SCRIPTS_DIR/clean_plugins.sh" --tmux-echo >/dev/null 2>&1
 	reload_tmux_environment
 	end_message

--- a/bindings/install_plugins
+++ b/bindings/install_plugins
@@ -11,7 +11,7 @@ source "$HELPERS_DIR/tmux_echo_functions.sh"
 source "$HELPERS_DIR/tmux_utils.sh"
 
 main() {
-	reload_tmux_environment
+	#reload_tmux_environment #This will cause tmux source-file ~/.tmux.conf twice and almost the same time
 	"$SCRIPTS_DIR/install_plugins.sh" --tmux-echo >/dev/null 2>&1
 	reload_tmux_environment
 	end_message

--- a/bindings/update_plugins
+++ b/bindings/update_plugins
@@ -42,7 +42,7 @@ update_plugin_prompt() {
 }
 
 main() {
-	reload_tmux_environment
+	#reload_tmux_environment #This will cause tmux source-file ~/.tmux.conf twice and almost the same time
 	display_plugin_update_list
 	update_plugin_prompt
 }


### PR DESCRIPTION
comment out the first "reload_tmux_environment" , to avoid tmux source-file ~/.tmux.conf twice and almost the same time, which will append contents twice , if I set status-left -ag (using -ag)

This will happen when:

`prefix` + <kbd>I</kbd>

`prefix` + <kbd>U</kbd>

`prefix` + <kbd>alt</kbd> + <kbd>u</kbd>