### PR TITLE
Non-Github Plugin Install Fails due to Syntax Error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # Other examples:
 # set -g @plugin 'github_username/plugin_name'
-# set -g @plugin 'git@github.com/user/plugin'
-# set -g @plugin 'git@bitbucket.com/user/plugin'
+# set -g @plugin 'git@github.com:user/plugin'
+# set -g @plugin 'git@bitbucket.com:user/plugin'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run -b '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
I thought it was a bit peculiar that the README.md suggested using `git@bitbucket.com/user/plugin`, but went ahead with that syntax. After seemingly endlessly scratching my head, while trying to figure out what the issue, I reverted to the traditional git URL syntax (SSH syntax) and it worked.

**Incorrect:**
```
set -g @plugin 'git@bitbucket.com/user/plugin_name`
```

**Correct:**
```
set -g @plugin 'git@bitbucket.com:user/plugin_name`
```

Verified by running `./.tmux/plugins/tpm/bin/install_plugins` manually with a fresh version of TMUX + TPM with both styles.

![image](https://user-images.githubusercontent.com/1456302/83681277-cca97300-a5a7-11ea-9541-94107e94822e.png)
