### PR TITLE
Use XDG-compatible plugin path when available

### DIFF
--- a/docs/changing_plugins_install_dir.md
+++ b/docs/changing_plugins_install_dir.md
@@ -1,6 +1,8 @@
 # Changing plugins install dir
 
-By default, TPM installs plugins to `~/.tmux/plugins/`.
+By default, TPM installs plugins in a subfolder named `plugins/` inside
+`$XDG_CONFIG_HOME/tmux/` if a `tmux.conf` file was found at that location, or
+inside `~/.tmux/` otherwise.
 
 You can change the install path by putting this in `.tmux.conf`:
 

--- a/tpm
+++ b/tpm
@@ -21,8 +21,17 @@ tpm_path_set() {
 	tmux show-environment -g "$DEFAULT_TPM_ENV_VAR_NAME" >/dev/null 2>&1
 }
 
+# Check if configuration file exists at an XDG-compatible location, if so use
+# that directory for TMUX_PLUGIN_MANAGER_PATH. Otherwise use $DEFAULT_TPM_PATH.
 set_default_tpm_path() {
-	tmux set-environment -g "$DEFAULT_TPM_ENV_VAR_NAME" "$DEFAULT_TPM_PATH"
+	local xdg_tmux_path="${XDG_CONFIG_HOME:-$HOME/.config}/tmux"
+	local tpm_path="$DEFAULT_TPM_PATH"
+
+	if [ -f "$xdg_tmux_path/tmux.conf" ]; then
+		tpm_path="$xdg_tmux_path/plugins/"
+	fi
+
+	tmux set-environment -g "$DEFAULT_TPM_ENV_VAR_NAME" "$tpm_path"
 }
 
 # Ensures TMUX_PLUGIN_MANAGER_PATH global env variable is set.


### PR DESCRIPTION
As discussed in #173, this PR adds a feature that detects if the configuration file is in `XDG_CONFIG_HOME`, and if that is the case, sets `TMUX_PLUGIN_MANAGER_PATH` to use that directory to store plugins.