### PR TITLE
Show errors of install_plugins

### DIFF
--- a/bindings/install_plugins
+++ b/bindings/install_plugins
@@ -12,7 +12,7 @@ source "$HELPERS_DIR/tmux_utils.sh"
 
 main() {
 	reload_tmux_environment
-	"$SCRIPTS_DIR/install_plugins.sh" --tmux-echo >/dev/null 2>&1
+	"$SCRIPTS_DIR/install_plugins.sh" --tmux-echo
 	reload_tmux_environment
 	end_message
 }


### PR DESCRIPTION
This PR makes plugin installation errors explicit.

## Why?

I had a typo in my `TMUX_PLUGIN_MANAGER_PATH` which made it empty. With this TPM tries to download the plugins to `/` which it won't have permission to.

However before this PR, running `ctrl+X and I` won't show any error and I'm left wondering where the problem might be, until I finally looked at TPM code, removed the discard of the `stderr` and got the following:

```
/ is not writable!                                                                                                                                                                       [0/0]
Installing "tpm"
  "tpm" download fail
Installing "vim-tmux-navigator"
  "vim-tmux-navigator" download fail
Installing "tmux-themepack"
  "tmux-themepack" download fail
Installing "tmux-resurrect"
  "tmux-resurrect" download fail
Installing "tmux-fingers"
  "tmux-fingers" download fail
TMUX environment reloaded.
Done, press ENTER to continue.
```

Which then immediately pointed me to the variable. Imo making errors explicit, at least these errors where user action is required makes for a better user experience.

Fixing the `TMUX_PLUGIN_MANAGER_PATH` solved the issue, but it would have been much faster if I had the error message to start with