### PR TITLE
relax condition for XDG-compatible plugin paths

### DIFF
--- a/docs/changing_plugins_install_dir.md
+++ b/docs/changing_plugins_install_dir.md
@@ -1,8 +1,8 @@
 # Changing plugins install dir
 
 By default, TPM installs plugins in a subfolder named `plugins/` inside
-`$XDG_CONFIG_HOME/tmux/` if a `tmux.conf` file was found at that location, or
-inside `~/.tmux/` otherwise.
+`$XDG_CONFIG_HOME/tmux/` if that directory exists, or inside `~/.tmux/`
+otherwise.
 
 You can change the install path by putting this in `.tmux.conf`:
 

--- a/tpm
+++ b/tpm
@@ -27,7 +27,7 @@ set_default_tpm_path() {
 	local xdg_tmux_path="${XDG_CONFIG_HOME:-$HOME/.config}/tmux"
 	local tpm_path="$DEFAULT_TPM_PATH"
 
-	if [ -f "$xdg_tmux_path/tmux.conf" ]; then
+	if [ -d "$xdg_tmux_path" ]; then
 		tpm_path="$xdg_tmux_path/plugins/"
 	fi
 


### PR DESCRIPTION
Instead of checking for the existence of the file `$XDG_CONFIG_HOME/tmux/tmux.conf`, we only check for the existence of the directory `$XDG_CONFIG_HOME/tmux`.

I ran into this because even though I keep my tmux configuration within `~/.config/tmux`, I don't use `tmux.conf` as one of my file names.

It's a simple fix on my end, but please lemme know if you're open to this change. Thanks!