### PR TITLE
[Bugfix] Remove hardcoding default branch as "master"

### DIFF
--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -13,9 +13,14 @@ else # shell output functions
 fi
 
 clone() {
-	local plugin="$1"
-	cd "$(tpm_path)" &&
-		GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
+	local plugin="$1" branch="$2"
+	if [ -n "$branch" ]; then
+		cd "$(tpm_path)" &&
+			GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
+	else
+		cd "$(tpm_path)" &&
+			GIT_TERMINAL_PROMPT=0 git clone --single-branch --recursive "$plugin" >/dev/null 2>&1
+	fi
 }
 
 # tries cloning:
@@ -30,8 +35,7 @@ clone_plugin() {
 
 # clone plugin and produce output
 install_plugin() {
-	local plugin="$1"
-	local branch=`[ -z "$2" ] && echo "master" || echo "$2"`
+	local plugin="$1" branch="$2"
 	local plugin_name="$(plugin_name_helper "$plugin")"
 
 	if plugin_already_installed "$plugin"; then


### PR DESCRIPTION
Default branch of repo could be "master", "main" or any names.
Stop hardcoding "master" as the default to clone and let "git"
decide it automatically.

Bug introduced in GH-158, resolves issue #208 