### PR TITLE
update_plugin: clashes with git config pull.rebase

### DIFF
--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -21,7 +21,7 @@ pull_changes() {
 	local plugin="$1"
 	local plugin_path="$(plugin_path_helper "$plugin")"
 	cd "$plugin_path" &&
-		GIT_TERMINAL_PROMPT=0 git pull &&
+		GIT_TERMINAL_PROMPT=0 git pull --rebase=false &&
 		GIT_TERMINAL_PROMPT=0 git submodule update --init --recursive
 }
 


### PR DESCRIPTION
Hello,
In my global git configuration, I set `pull.rebase` to `interactive` (more info in git documentation [for git pull](https://www.git-scm.com/docs/git-pull#Documentation/git-pull.txt---rebasefalsetruemergespreserveinteractive) and [for git config](https://www.git-scm.com/docs/git-config#Documentation/git-config.txt-pullrebase))
While this might be a quite extravagant configuration, it breaks the updates for tpm, as it relies on the fact that `git pull` is a non-interactive command. Which is definitely not in my weird configuration.

Explicitly passing the `--rebase=false` should force the default behavior. It fixes the issue in my configuration and should have no impact on others.

Thanks! :)