### PR TITLE
Quick fix for #213 :hammer:

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -74,7 +74,7 @@ tpm_plugins_list_helper() {
 
 	# read set -g @plugin "tmux-plugins/tmux-example-plugin" entries
 	_tmux_conf_contents "full" |
-		awk '/^[ \t]*set(-option)? +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); print $4 }'
+		awk '/^[ \t]*set(-option)? +-g +@plugin/ { gsub(/'\''/,""); gsub(/'\"'/,""); print tolower($4) }'
 }
 
 # Allowed plugin name formats:


### PR DESCRIPTION
# Quick fix for #213 :hammer:
somehow uppercase letters in the plugin name make the server freeze and after the restart, it shows the "server exited unexpectedly" message!

> for more info please read #213