### PR TITLE
fix: typo

### DIFF
--- a/docs/how_to_create_plugin.md
+++ b/docs/how_to_create_plugin.md
@@ -92,12 +92,12 @@ That should set up the key binding. Now hit `prefix + T` and see if it works.
 ### 6. publish the plugin
 
 When everything is ready, push the plugin to an online git repository,
-preferably Github.
+preferably GitHub.
 
 Other users can install your plugin by just adding plugin git URL to the
 `@plugin` list in their `.tmux.conf`.
 
-If the plugin is on Github, your users will be able to use the shorthand of
+If the plugin is on GitHub, your users will be able to use the shorthand of
 `github_username/repository`.
 
 ### Conclusion

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -26,7 +26,7 @@ clone() {
 
 # tries cloning:
 # 1. plugin name directly - works if it's a valid git url
-# 2. expands the plugin name to point to a github repo and tries cloning again
+# 2. expands the plugin name to point to a GitHub repo and tries cloning again
 clone_plugin() {
 	local plugin="$1"
 	local branch="$2"


### PR DESCRIPTION
The official name of GitHub is changed from `Github` to `GitHub` because `h` is uppercase.