### PR TITLE
feat: add support for installing two plugins with same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 # set -g @plugin 'github_username/plugin_name#branch'
 # set -g @plugin 'git@github.com:user/plugin'
 # set -g @plugin 'git@bitbucket.com:user/plugin'
+# set -g @plugin 'awesome_plugin::github_username/plugin_name'
+# set -g @plugin 'awesome_plugin::git@github.com:user/plugin'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -80,8 +80,15 @@ tpm_plugins_list_helper() {
 # Allowed plugin name formats:
 # 1. "git://github.com/user/plugin_name.git"
 # 2. "user/plugin_name"
+# 3. "plugin_name::git://github.com/user/plugin_name.git"
+# 4. "plugin_name::user/plugin"
 plugin_name_helper() {
 	local plugin="$1"
+	# if a plugin name is specified, use it
+	if [[ "$plugin" = *::* ]]; then
+		echo "${plugin%%::*}"
+		return
+	fi
 	# get only the part after the last slash, e.g. "plugin_name.git"
 	local plugin_basename="$(basename "$plugin")"
 	# remove ".git" extension (if it exists) to get only "plugin_name"

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -15,12 +15,13 @@ fi
 clone() {
 	local plugin="$1"
 	local branch="$2"
+	local plugin_name="$3"
 	if [ -n "$branch" ]; then
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" "$plugin_name" >/dev/null 2>&1
 	else
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone --single-branch --recursive "$plugin" >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 git clone --single-branch --recursive "$plugin" "$plugin_name" >/dev/null 2>&1
 	fi
 }
 
@@ -28,10 +29,12 @@ clone() {
 # 1. plugin name directly - works if it's a valid git url
 # 2. expands the plugin name to point to a GitHub repo and tries cloning again
 clone_plugin() {
-	local plugin="$1"
+	# strip the eventual plugin name
+	local plugin="${1#*::}"
 	local branch="$2"
-	clone "$plugin" "$branch" ||
-		clone "https://git::@github.com/$plugin" "$branch"
+	local plugin_name="$3"
+	clone "$plugin" "$branch" "$plugin_name" ||
+		clone "https://git::@github.com/$plugin" "$branch" "$plugin_name"
 }
 
 # clone plugin and produce output
@@ -44,7 +47,7 @@ install_plugin() {
 		echo_ok "Already installed \"$plugin_name\""
 	else
 		echo_ok "Installing \"$plugin_name\""
-		clone_plugin "$plugin" "$branch" &&
+		clone_plugin "$plugin" "$branch" "$plugin_name" &&
 			echo_ok "  \"$plugin_name\" download success" ||
 			echo_err "  \"$plugin_name\" download fail"
 	fi


### PR DESCRIPTION
As it is mentioned in #183, current tpm does not support install two or more plugin with same name.

This PR try to add a feature that support define an alias name for plugins.

For example:

```
set -g @plugin 'awesome_plugin::github_username/plugin_name'
set -g @plugin 'awesome_plugin::git@github.com:user/plugin'
```