### PR TITLE
Restroring progress indication, gone since 2.4

### DIFF
--- a/bindings/update_plugins
+++ b/bindings/update_plugins
@@ -18,7 +18,6 @@ source "$HELPERS_DIR/tmux_utils.sh"
 display_plugin_update_list() {
 	local plugins="$(tpm_plugins_list_helper)"
 	tmux_echo "Installed plugins:"
-	tmux_echo ""
 
 	for plugin in $plugins; do
 		# displaying only installed plugins

--- a/scripts/clean_plugins.sh
+++ b/scripts/clean_plugins.sh
@@ -34,8 +34,10 @@ clean_plugins() {
 }
 
 main() {
+	set_long_tmux_display_time
 	ensure_tpm_path_exists
 	clean_plugins
+	tmux set-option -g display-time "$org_display_time" #  Restore display-time
 	exit_value_helper
 }
 main

--- a/scripts/helpers/tmux_echo_functions.sh
+++ b/scripts/helpers/tmux_echo_functions.sh
@@ -4,6 +4,7 @@ _has_emacs_mode_keys() {
 
 tmux_echo() {
 	local message="$1"
+	tmux display-message "$message"
 	tmux run-shell "echo '$message'"
 }
 
@@ -13,6 +14,7 @@ echo_ok() {
 
 echo_err() {
 	tmux_echo "$*"
+	sleep 3  #  Give some time for error message to be displayed in status bar
 }
 
 end_message() {

--- a/scripts/helpers/utility.sh
+++ b/scripts/helpers/utility.sh
@@ -15,3 +15,18 @@ exit_value_helper() {
 		exit 0
 	fi
 }
+
+set_long_tmux_display_time() {
+	#
+	#  Since tmux display is used to indicate progress, save original
+	#  display-time and temporarily set it to 2 minutes.
+	#  New messages will overwrite previous, so this is not blocking anything.
+	#  It is just a random long time to ensure that the messages don't time-out.
+	#
+	#  Use this to restore the original display-time before exiting:
+	#
+	#   tmux set-option -g display-time "$org_display_time"
+	#
+	org_display_time="$(tmux show-options -g display-time | awk '{print $2}')"
+	tmux set-option -g display-time 120000
+}

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -67,9 +67,11 @@ verify_tpm_path_permissions() {
 }
 
 main() {
+	set_long_tmux_display_time
 	ensure_tpm_path_exists
 	verify_tpm_path_permissions
 	install_plugins
+	tmux set-option -g display-time "$org_display_time" #  Restore display-time
 	exit_value_helper
 }
 main

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -62,12 +62,14 @@ update_plugins() {
 }
 
 main() {
+	set_long_tmux_display_time
 	ensure_tpm_path_exists
 	if [ "$1" == "all" ]; then
 		update_all
 	else
 		update_plugins "$*"
 	fi
+	tmux set-option -g display-time "$org_display_time" #  Restore display-time
 	exit_value_helper
 }
 main "$*"

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -34,7 +34,6 @@ update() {
 
 update_all() {
 	echo_ok "Updating all plugins!"
-	echo_ok ""
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
 		IFS='#' read -ra plugin <<< "$plugin"


### PR DESCRIPTION
Progress has been missing in tpm since tmux 2.4

Tmux run-shell only displays output in copy mode up to version 2.3.
After that, it is printed in view mode, and the result is scripted `run-shell "echo $msg"` will not be displayed as they happen.

By removing the  > /dev/null 2>&1 in bindings/clean_plugins & install_plugins, the echoes will be displayed once the process is completed, same as for bindings/update_plugins. Since I do not know the reason for those > /dev/null statements, I did not remove them, somebody probably had a reason to put them there at some point. 

But starting with 2.4 echo progress will not be real-time regardless of /dev/null usage or not, take update_plugins as an example, all progress is displayed once the process is completed.

With this display-message approach, progress indication is restored, and far superior compared to only seeing what is intended as step-by-step progress reports after the sometimes lengthy process is completed.

I set a sleep for error messages, to give them time to be read before being overwritten by the next message. I selected 3 seconds here, it seems reasonable.

I have tested this all the way down to tmux  version 2.0
For versions 2.0-2.3 both echo and display-message will indicate progress, so duplication yes, but it does not have any negative impact.
