### PR TITLE
Add `--depth=1` to git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements: `tmux` version 1.9 (or higher), `git`, `bash`.
 Clone TPM:
 
 ```bash
-$ git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+$ git clone --depth=1 https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 ```
 
 Put this at the bottom of `~/.tmux.conf` (`$XDG_CONFIG_HOME/tmux/tmux.conf`


### PR DESCRIPTION
Add `--depth=1` to the README's git clone command to do a shallow clone of just the head of the repo. This will save users a little bit of network and disk if they're copy-pasting from the instructions.