### PR TITLE
add support for variable expansion in config files

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -46,7 +46,8 @@ _tmux_conf_contents() {
 # return files sourced from tmux config files
 _sourced_files() {
 	_tmux_conf_contents |
-		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-q+[[:space:]]+)?['\"]?([^'\"]+)['\"]?/\3/p"
+		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-q+[[:space:]]+)?(['\"]?[^'\"]+['\"]?)/echo \3/p" |
+		/usr/bin/env bash
 }
 
 # Want to be able to abort in certain cases


### PR DESCRIPTION
If tmux.conf refers other file by source-file command that uses variable, it'll be better to expand variables into actual values.

### Background

In XDG style directory, I'd like to use `tmux.conf` with variables like following example.

```sh
# tmux.conf ------------------------------------------------

TMUX_CONF_PATH="~/.config/tmux"

source "${TMUX_CONF_PATH}/general.conf"
source "${TMUX_CONF_PATH}/plugins.conf"
source "${TMUX_CONF_PATH}/pane.conf"
source "${TMUX_CONF_PATH}/status.conf"


# plugins.conf ---------------------------------------------

TMUX_PLUGIN_MANAGER_PATH="~/.local/share/tmux/plugins"

set -g @plugin 'tmux-plugins/tpm'
set -g @plugin 'tmux-plugins/tmux-sensible'

run "${TMUX_PLUGIN_MANAGER_PATH}/tpm/tpm"
```

It works well about tmux configurations, but tpm can't read `@plugin` entries from `plugins.conf`.

Current version of tpm expands `~` to `$HOME` with `_manual_expansion()` function, but never expands variables.

### Solution

In `_sourced_files()` function, tpm extract parameter of `source-file` commands from `tmux.conf`.

We can put these parameters into `echo` command and process with `bash`, then get filenames with parameters expanded. Both single and double quotation marks are must be recognized correctly.

```sh
# intermediate script, to be processed with bash

echo "${TMUX_CONF_PATH}/general.conf"
echo "${TMUX_CONF_PATH}/plugins.conf"
echo "${TMUX_CONF_PATH}/pane.conf"
echo "${TMUX_CONF_PATH}/status.conf"
```
