### PR TITLE
Update automatic tpm installation instructions to avoid linting error

### DIFF
--- a/docs/automatic_tpm_installation.md
+++ b/docs/automatic_tpm_installation.md
@@ -5,7 +5,7 @@ One of the first things we do on a new machine is cloning our dotfiles. Not ever
 If you want to install `tpm` and plugins automatically when tmux is started, put the following snippet in `.tmux.conf` before the final `run '~/.tmux/plugins/tpm/tpm'`:
 
 ```
-if "test ! -d ~/.tmux/plugins/tpm" \
+if-shell "test ! -d ~/.tmux/plugins/tpm" \
    "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 ```
 

--- a/docs/automatic_tpm_installation.md
+++ b/docs/automatic_tpm_installation.md
@@ -9,4 +9,4 @@ if-shell "test ! -d ~/.tmux/plugins/tpm" \
    "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 ```
 
-This useful tip was submitted by @acr4 and narfman0.
+This useful tip was submitted by [@acr4](https://github.com/acr4) and [@narfman0](https://github.com/narfman0).


### PR DESCRIPTION
Currently the automatic tpm instructions are detected as syntax error by VS Code (`1:1: "if <cond>" must be followed by "then"`). This can be fixed by using `if-shell` instead (`if` is an alias for `if-shell` so behaviour should be identical, more info at https://linux.die.net/man/1/tmux).

![image](https://user-images.githubusercontent.com/35803280/201730864-24ccca67-e1d9-41a7-9f30-111244f23341.png)

I also added some hyperlinks to original author profiles.
