### PR TITLE
Support comma as delimiter for “@tpm_plugins”

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -70,7 +70,10 @@ tpm_path() {
 
 tpm_plugins_list_helper() {
 	# lists plugins from @tpm_plugins option
-	echo "$(tmux start-server\; show-option -gqv "$tpm_plugins_variable_name")"
+	local plugins
+	plugins="$(tmux start-server\; show-option -gqv "$tpm_plugins_variable_name")"
+	plugins="${plugins//,/ }"
+	echo "$plugins"
 
 	# read set -g @plugin "tmux-plugins/tmux-example-plugin" entries
 	_tmux_conf_contents "full" |

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -69,9 +69,10 @@ tpm_path() {
 }
 
 tpm_plugins_list_helper() {
-	# lists plugins from @tpm_plugins option
 	local plugins
+	# lists plugins from @tpm_plugins option
 	plugins="$(tmux start-server\; show-option -gqv "$tpm_plugins_variable_name")"
+	# allow comma as a plugin separator
 	plugins="${plugins//,/ }"
 	echo "$plugins"
 


### PR DESCRIPTION
Notes:
1. Empty elements will be ignored.
2. Double slash means global replacement. See [Bash manual](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).