### PR TITLE
Show the output of Git pull when updating plugins

### DIFF
--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -26,10 +26,15 @@ pull_changes() {
 }
 
 update() {
-	local plugin="$1"
-	$(pull_changes "$plugin" > /dev/null 2>&1) &&
-		echo_ok "  \"$plugin\" update success" ||
+	local plugin="$1" output
+	output=$(pull_changes "$plugin" 2>&1)
+	if (( $? == 0 )); then
+		echo_ok "  \"$plugin\" update success"
+		echo_ok "$(echo "$output" | sed -e 's/^/    | /')"
+	else
 		echo_err "  \"$plugin\" update fail"
+		echo_err "$(echo "$output" | sed -e 's/^/    | /')"
+	fi
 }
 
 update_all() {


### PR DESCRIPTION
This tells users whether a plugin changed during the update. When update succeed, it shows something like

```plain
Updating all plugins!

  "tmux-resurrect" update success
    | Already latest.
  "foo-bar" update success
    | Already latest.
```

When it fail, it shows something like

```plain
Updating all plugins!

  "tmux-resurrect" update fail
    | remote: Support for password authentication was removed on August 13, 2021.
    | Fatal: 'https://github.com/tmux-plugins/tmux-resurrectt/' authentication fail
  "foo-bar" update success
    | Already latest.
```

Difference from #84:

 1. Make the variable local.
 2. Put the status after the main message, so that it looks like a tree (after indentation).

Decision that requires last call from maintainer: whether we want to always show it, or hide it behind some command-line flag (or environment variable, or tmux configuration variable).

Fixes #76.