### PR TITLE
Update tpm_not_working.md

### DIFF
--- a/docs/tpm_not_working.md
+++ b/docs/tpm_not_working.md
@@ -85,12 +85,18 @@ find ~/.tmux -type d -name '.git*' -prune -o -type f -print0 | xargs -0 dos2unix
 
 Related: [issue #67](https://github.com/tmux-plugins/tpm/issues/67)
 
-This problem is because tmux's `run-shell` command runs a shell which doesn't read from user configs, thus tmux installed in `/usr/local/bin` will not be found.
+This problem is because tmux's `run-shell` command runs a shell which doesn't read from user configs, thus tmux installed in a brew prefix (e.g. `/usr/local/bin`) will not be found.
 
-The solution is to insert the following line:
+The solution is to find your brew prefix
 
+```sh
+> echo "$(brew --prefix)/bin"
+/opt/homebrew/bin
 ```
-set-environment -g PATH "/usr/local/bin:/bin:/usr/bin"
+
+And prefix it to the `PATH` environment variable
+```
+set-environment -g PATH "/opt/homebrew/bin:/bin:/usr/bin"
 ```
 
 before any `run-shell`/`run` commands in `~/.tmux.conf`.

--- a/docs/tpm_not_working.md
+++ b/docs/tpm_not_working.md
@@ -94,7 +94,7 @@ The solution is to find your brew prefix
 /opt/homebrew/bin
 ```
 
-And prefix it to the `PATH` environment variable
+And prepend it to the `PATH` environment variable
 ```
 set-environment -g PATH "/opt/homebrew/bin:/bin:/usr/bin"
 ```


### PR DESCRIPTION
Thanks for all the great work!

The [brew](https://github.pie.apple.com/homebrew/brew) prefix varies across architectures. I've added a suggestion to the guide remove assumptions about it's value.