### PR TITLE
Support sourced file names in tmux format

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -5,7 +5,7 @@ tpm_plugins_variable_name="@tpm_plugins"
 _manual_expansion() {
 	local path="$1"
 	local expanded_tilde="${path/#\~/$HOME}"
-	echo "${expanded_tilde/#\$HOME/$HOME}"
+	tmux display-message -p "${expanded_tilde/#\$HOME/$HOME}"
 }
 
 _tpm_path() {
@@ -46,7 +46,7 @@ _tmux_conf_contents() {
 # return files sourced from tmux config files
 _sourced_files() {
 	_tmux_conf_contents |
-		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-q+[[:space:]]+)?['\"]?([^'\"]+)['\"]?/\3/p"
+		sed -E -n -e "s/^[[:space:]]*source(-file)?[[:space:]]+(-[qF]+[[:space:]]+)?['\"]?([^'\"]+)['\"]?/\3/p"
 }
 
 # Want to be able to abort in certain cases

--- a/tests/test_plugin_installation.sh
+++ b/tests/test_plugin_installation.sh
@@ -250,6 +250,33 @@ test_plugins_installation_from_sourced_file_via_script() {
 	teardown_helper
 }
 
+test_plugins_installation_from_sourced_file_name_in_tmux_format_via_script() {
+	set_tmux_conf_helper <<- HERE
+	set -g mode-keys vi
+	set -g ADDITIONAL_CONFIG_FILE "$ADDITIONAL_CONFIG_FILE_1"
+	source -F '#{ADDITIONAL_CONFIG_FILE}'
+	set -g @plugin 'tmux-plugins/tmux-example-plugin'
+	run-shell "$TPM_DIR/tpm"
+	HERE
+
+	mkdir ~/.tmux
+	echo "set -g @plugin 'tmux-plugins/tmux-copycat'" > "$ADDITIONAL_CONFIG_FILE_1"
+
+	script_run_helper "$TPM_DIR/bin/install_plugins" '"tmux-copycat" download success' ||
+		fail_helper "[script][sourced file] plugins installation fails"
+
+	check_dir_exists_helper "$PLUGINS_DIR/tmux-example-plugin/" ||
+		fail_helper "[script][sourced file] plugin download fails (tmux-example-plugin)"
+
+	check_dir_exists_helper "$PLUGINS_DIR/tmux-copycat/" ||
+		fail_helper "[script][sourced file] plugin download fails (tmux-copycat)"
+
+	script_run_helper "$TPM_DIR/bin/install_plugins" 'Already installed "tmux-copycat"' ||
+		fail_helper "[script][sourced file] plugins already installed message fail"
+
+	teardown_helper
+}
+
 test_plugins_installation_from_multiple_sourced_files_via_script() {
 	set_tmux_conf_helper <<- HERE
 	set -g mode-keys vi


### PR DESCRIPTION
Recently oh-my-tmux [1] updated to support placing its files in
directories other than HOME like ~/.config and XDG_CONFIG_HOME.

So now instead of a static file name, we need some sort of variable
expansion and I think tmux format fits the role quite well.

[1] https://github.com/gpakosz/.tmux
