### PR TITLE
changed @tpm_plugins to @plugin and fixed tmux show-option

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -1,5 +1,5 @@
 # using @tpm_plugins is now deprecated in favor of using @plugin syntax
-tpm_plugins_variable_name="plugin"
+tpm_plugins_variable_name="@plugin"
 
 # manually expanding tilde char or `$HOME` variable.
 _manual_expansion() {

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -1,5 +1,5 @@
 # using @tpm_plugins is now deprecated in favor of using @plugin syntax
-tpm_plugins_variable_name="@tpm_plugins"
+tpm_plugins_variable_name="plugin"
 
 # manually expanding tilde char or `$HOME` variable.
 _manual_expansion() {
@@ -70,7 +70,7 @@ tpm_path() {
 
 tpm_plugins_list_helper() {
 	# lists plugins from @tpm_plugins option
-	echo "$(tmux start-server\; show-option -gqv "$tpm_plugins_variable_name")"
+	echo "$(tmux start-server;tmux show-option -gqv "$tpm_plugins_variable_name")"
 
 	# read set -g @plugin "tmux-plugins/tmux-example-plugin" entries
 	_tmux_conf_contents "full" |


### PR DESCRIPTION
fix for #246 
- changed the @tpm_plugins to @plugin at the top of scripts/helpers/plugin_functions.sh (a comment just above it says to use @plugin but @tpm_plugins was still being used for some reason)
- added `tmux` in front of the show-option command in tpm_plugins_list_helper(). Otherwise i was getting an error 'show-option command not found'