### PR TITLE
fix: not sourcing paths written with variables or ~

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -38,7 +38,7 @@ _tmux_conf_contents() {
 	if [ "$1" == "full" ]; then # also output content from sourced files
 		local file
 		for file in $(_sourced_files); do
-			cat $(_manual_expansion "$file") 2>/dev/null
+			cat "$(eval echo "$(_manual_expansion "$file")")" 2>/dev/null
 		done
 	fi
 }


### PR DESCRIPTION
Related to #233 (and probably to #244)

This is a fix, not an addition, since even `$HOME` was not expanded which is definitely not intended, since there is a function substituting `~` for `$HOME`.