### PR TITLE
Colourise update response to make failure more apparent

### DIFF
--- a/bindings/update_plugins
+++ b/bindings/update_plugins
@@ -7,6 +7,11 @@
 # - shows a list of installed plugins
 # - starts a prompt to enter the name of the plugin that will be updated
 
+if command -v tput >/dev/null; then
+	yellow=$(tput setaf 3)
+	norm=$(tput sgr0)
+fi
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SCRIPTS_DIR="$CURRENT_DIR/../scripts"
 HELPERS_DIR="$SCRIPTS_DIR/helpers"
@@ -24,7 +29,7 @@ display_plugin_update_list() {
 		# displaying only installed plugins
 		if plugin_already_installed "$plugin"; then
 			local plugin_name="$(plugin_name_helper "$plugin")"
-			tmux_echo "  $plugin_name"
+			tmux_echo "  ${yellow}${plugin_name}${norm}"
 		fi
 	done
 

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -2,6 +2,13 @@
 
 # this script handles core logic of updating plugins
 
+if command -v tput >/dev/null; then
+	red=$(tput setaf 1)
+	green=$(tput setaf 2)
+	yellow=$(tput setaf 3)
+	norm=$(tput sgr0)
+fi
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HELPERS_DIR="$CURRENT_DIR/helpers"
 
@@ -29,10 +36,10 @@ update() {
 	local plugin="$1" output
 	output=$(pull_changes "$plugin" 2>&1)
 	if (( $? == 0 )); then
-		echo_ok "  \"$plugin\" update success"
+		echo_ok "  \"${yellow}${plugin}${norm}\" ${green}update success${norm}"
 		echo_ok "$(echo "$output" | sed -e 's/^/    | /')"
 	else
-		echo_err "  \"$plugin\" update fail"
+		echo_err "  \"${yellow}${plugin}${norm}\" ${red}update fail${norm}"
 		echo_err "$(echo "$output" | sed -e 's/^/    | /')"
 	fi
 }


### PR DESCRIPTION
It's too easy to miss when an update fails, so this makes the result much quicker to understand at a glance by adding some colour. This is what it will look like in a terminal with standard-ish ANSI colours.

![image](https://github.com/tmux-plugins/tpm/assets/815311/3b460562-334e-4601-b1b1-7940dde5d668)