### PR TITLE
Escape bindings dir

### DIFF
--- a/scripts/source_plugins.sh
+++ b/scripts/source_plugins.sh
@@ -14,14 +14,13 @@ plugin_dir_exists() {
 # No errors if the plugin dir does not exist.
 silently_source_all_tmux_files() {
 	local plugin_path="$1"
-	local plugin_tmux_files="$plugin_path*.tmux"
 	if plugin_dir_exists "$plugin_path"; then
-		for tmux_file in $plugin_tmux_files; do
+		for tmux_file in "$plugin_path"/*.tmux; do
 			# if the glob didn't find any files this will be the
 			# unexpanded glob which obviously doesn't exist
 			[ -f "$tmux_file" ] || continue
 			# runs *.tmux file as an executable
-			$tmux_file >/dev/null 2>&1
+			"$tmux_file" >/dev/null 2>&1
 		done
 	fi
 }

--- a/tpm
+++ b/tpm
@@ -57,14 +57,16 @@ source_plugins() {
 # prefix + U - updates a plugin (or all of them) and reloads TMUX environment
 # prefix + alt + u - remove unused TPM plugins and reloads TMUX environment
 set_tpm_key_bindings() {
+	tmux set-environment -g TPM_BINDINGS_DIR "$BINDINGS_DIR"
+
 	local install_key="$(get_tmux_option "$install_key_option" "$default_install_key")"
-	tmux bind-key "$install_key" run-shell "$BINDINGS_DIR/install_plugins"
+	tmux bind-key "$install_key" run-shell "#{q:TPM_BINDINGS_DIR}/install_plugins"
 
 	local update_key="$(get_tmux_option "$update_key_option" "$default_update_key")"
-	tmux bind-key "$update_key" run-shell "$BINDINGS_DIR/update_plugins"
+	tmux bind-key "$update_key" run-shell "#{q:TPM_BINDINGS_DIR}/update_plugins"
 
 	local clean_key="$(get_tmux_option "$clean_key_option" "$default_clean_key")"
-	tmux bind-key "$clean_key" run-shell "$BINDINGS_DIR/clean_plugins"
+	tmux bind-key "$clean_key" run-shell "#{q:TPM_BINDINGS_DIR}/clean_plugins"
 }
 
 supported_tmux_version_ok() {


### PR DESCRIPTION
Currently, the `bind-key` commands fail if `BINDINGS_DIR` (via TPM's installation path) contains characters that need to be escaped in sh-syntax. The most obvious example is spaces. 

e.g. `TMUX_PLUGIN_MANAGER_PATH=/Users/foobar/Library/Application Support/tmux/plugins` causes `install_key` to be bound to sh -c `/Users/foobar/Library/Application Support/tmux/plugins/tpm/bindings/install_plugins` which is interpreted as the command `/Users/foobar/Library/Application` with a single argument of `Support/tmux/plugins/tpm/bindings/install_plugins`.

This PR fixes this by using tmux's built-in sh-escaping (the `#{q:...}` format string syntax). This requires a new tmux environment variable. 