### PR TITLE
use env TMUX_CONF_FILE to override default tmux.conf locations, #205

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -33,7 +33,13 @@ _get_user_tmux_conf() {
 }
 
 _tmux_conf_contents() {
-	user_config=$(_get_user_tmux_conf)
+
+        if [ -n "$TMUX_CONF_FILE" ]; then
+            user_config="$TMUX_CONF_FILE"
+        else
+            user_config=$(_get_user_tmux_conf)
+        fi
+
 	cat /etc/tmux.conf "$user_config" 2>/dev/null
 	if [ "$1" == "full" ]; then # also output content from sourced files
 		local file


### PR DESCRIPTION
TMUX_CONF_FILE takes precendace over $HOME/.tmux.conf or XDG_CONFIG_HOME/tmux/tmux.conf which allows internal tpm scripts to properly parse user_config

E.g in your tmux.conf.local which is sourced by tmux.conf add set-environment -g "TMUX_CONF_FILE" "/path/to/tmux.conf.local"

In essence this is similar as PR: #163, but it must be faster as we are not calling tmux and relay on _tmux_conf_contents