### PR TITLE
Fix naming conflicts and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements: `tmux` version 1.9 (or higher), `git`, `bash`.
 Clone TPM:
 
 ```bash
-git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tmux-plugins/tpm
 ```
 
 Put this at the bottom of `~/.tmux.conf` (`$XDG_CONFIG_HOME/tmux/tmux.conf`
@@ -28,12 +28,12 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # Other examples:
 # set -g @plugin 'github_username/plugin_name'
-# set -g @plugin 'github_username/plugin_name#branch'
+# set -g @plugin 'github_username/plugin_name#branch_or_tag'
 # set -g @plugin 'git@github.com:user/plugin'
 # set -g @plugin 'git@bitbucket.com:user/plugin'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.tmux/plugins/tmux-plugins/tpm/tpm'
 ```
 
 Reload TMUX environment so TPM is sourced:

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -82,10 +82,11 @@ tpm_plugins_list_helper() {
 # 2. "user/plugin_name"
 plugin_name_helper() {
 	local plugin="$1"
-	# get only the part after the last slash, e.g. "plugin_name.git"
-	local plugin_basename="$(basename "$plugin")"
+	# get only the last part
+	IFS='/' read -ra plugin <<< "$plugin"
+	plugin="${plugin[-2]}/${plugin[-1]}"
 	# remove ".git" extension (if it exists) to get only "plugin_name"
-	local plugin_name="${plugin_basename%.git}"
+	local plugin_name="${plugin%.git}"
 	echo "$plugin_name"
 }
 

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -98,7 +98,8 @@ plugin_path_helper() {
 
 plugin_already_installed() {
 	local plugin="$1"
-	local plugin_path="$(plugin_path_helper "$plugin")"
+	IFS='#' read -ra plugin <<< "$plugin"
+	local plugin_path="$(plugin_path_helper "${plugin[0]}")"
 	[ -d "$plugin_path" ] &&
 		cd "$plugin_path" &&
 		git remote >/dev/null 2>&1

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -82,10 +82,21 @@ tpm_plugins_list_helper() {
 # 2. "user/plugin_name"
 plugin_name_helper() {
 	local plugin="$1"
-	# get only the last part
-	IFS='/' read -ra plugin <<< "$plugin"
-	plugin="${plugin[-2]}/${plugin[-1]}"
-	# remove ".git" extension (if it exists) to get only "plugin_name"
+	# Extract user/repo from different URL formats
+	if [[ "$plugin" == "https://"* ]] || [[ "$plugin" == "git@"* ]]; then
+		# Handle full URLs
+		plugin=$(echo "$plugin" | sed -E 's/.*[\/:]([^\/]+\/[^\/]+)\.git?$/\1/')
+	else
+		# Handle user/repo format
+		IFS='/' read -ra plugin_parts <<< "$plugin"
+		if [[ ${#plugin_parts[@]} -eq 2 ]]; then
+			plugin="${plugin_parts[0]}/${plugin_parts[1]}"
+		else
+			# get only the last two parts for longer paths
+			plugin="${plugin_parts[-2]}/${plugin_parts[-1]}"
+		fi
+	fi
+	# remove ".git" extension (if it exists) to get only "user/repo"
 	local plugin_name="${plugin%.git}"
 	echo "$plugin_name"
 }

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -52,15 +52,8 @@ install_plugin() {
 install_plugins() {
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
-		if [[ "$plugin" == *#* ]]; then
-			IFS='#' read -ra plugin <<< "$plugin"
-			install_plugin "${plugin[0]}" "${plugin[1]}"
-		elif [[ "$plugin" == *@* ]]; then
-			IFS='@' read -ra plugin <<< "$plugin"
-			install_plugin "${plugin[0]}" "${plugin[1]}"
-		else
-			install_plugin ${plugin}
-		fi
+		IFS='#' read -ra plugin <<< "$plugin"
+		install_plugin "${plugin[0]}" "${plugin[1]}"
 	done
 }
 

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -14,15 +14,26 @@ fi
 
 clone() {
 	local plugin="$1"
-	[[ -z "$2" ]] && local branch="" || local branch="--branch $2"
-	if [[ ! $plugin == *"https://"* ]]; then
+	local ref="$2"
+	local clone_options=""
+	
+	# Handle both branches and tags
+	if [[ -n "$ref" ]]; then
+		clone_options="--branch $ref"
+	fi
+	
+	local plugin_name="$(plugin_name_helper "$plugin")"
+	local plugin_dir="$(tpm_path)${plugin_name}/"
+	
+	# Create the user directory if it doesn't exist
+	mkdir -p "$(dirname "$plugin_dir")"
+	
+	if [[ ! $plugin == *"https://"* ]] && [[ ! $plugin == *"git@"* ]]; then
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone $branch --single-branch --recursive "https://git::@github.com/$plugin" $plugin >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 git clone $clone_options --single-branch --recursive "https://git::@github.com/$plugin" "$plugin_name" >/dev/null 2>&1
 	else
-		local basename_with_git="$(basename "$plugin")"
-		local basename="${basename_with_git%.git}"
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone $branch --single-branch --recursive "$basename" $basename >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 git clone $clone_options --single-branch --recursive "$plugin" "$plugin_name" >/dev/null 2>&1
 	fi
 }
 

--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -42,10 +42,10 @@ update_all() {
 	echo_ok ""
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
-		IFS='#' read -ra plugin <<< "$plugin"
-		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
-		# updating only installed plugins
-		if plugin_already_installed "$plugin_name"; then
+		IFS='#' read -ra plugin_parts <<< "$plugin"
+		local plugin_name="$(plugin_name_helper "${plugin_parts[0]}")"
+		# updating only installed plugins - check with full plugin spec to handle branch/tag
+		if plugin_already_installed "$plugin"; then
 			update "$plugin_name" &
 		fi
 	done
@@ -55,9 +55,9 @@ update_all() {
 update_plugins() {
 	local plugins="$*"
 	for plugin in $plugins; do
-		IFS='#' read -ra plugin <<< "$plugin"
-		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
-		if plugin_already_installed "$plugin_name"; then
+		IFS='#' read -ra plugin_parts <<< "$plugin"
+		local plugin_name="$(plugin_name_helper "${plugin_parts[0]}")"
+		if plugin_already_installed "$plugin"; then
 			update "$plugin_name" &
 		else
 			echo_err "$plugin_name not installed!" &


### PR DESCRIPTION
This PR fix:
- #273
using `.tmux/plugins/<user>/<repo>` plugin's dir structure

- #87
nothing done here, instead of #branch you can use #tag

- when updating plugins with #branch were not showing