### PR TITLE
fix(cli,install): authenticity of host 'github.com' can't be established

### DIFF
--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -17,10 +17,10 @@ clone() {
 	local branch="$2"
 	if [ -n "$branch" ]; then
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=yes' git clone -b "$branch" --single-branch --recursive "$plugin" >/dev/null 2>&1
 	else
 		cd "$(tpm_path)" &&
-			GIT_TERMINAL_PROMPT=0 git clone --single-branch --recursive "$plugin" >/dev/null 2>&1
+			GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=yes' git clone --single-branch --recursive "$plugin" >/dev/null 2>&1
 	fi
 }
 
@@ -31,7 +31,7 @@ clone_plugin() {
 	local plugin="$1"
 	local branch="$2"
 	clone "$plugin" "$branch" ||
-		clone "https://git::@github.com/$plugin" "$branch"
+		clone "https://github.com/$plugin" "$branch"
 }
 
 # clone plugin and produce output


### PR DESCRIPTION
When using the `install_plugins` command noninteractively on automation platforms such as GitHub Actions or Ansible, it can sometimes hang and never complete. When I ran the command interactively, it prompted me to either accept or reject to the host key of an unknown host.

```
The authenticity of host 'github.com (20.87.245.0)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])?
``` 

I found out the cause was the plugin https://github.com/alexwforsythe/tmux-which-key having a git submodule with an SSH URL: https://github.com/alexwforsythe/tmux-which-key/blob/main/.gitmodules . For open source projects, this is an error.

This pull request proposes to exit the `install_plugins` command immediately if the host is unknown.

Resolves #219