### PR TITLE
fixing: fixing tpm not working with spaces user dir

### DIFF
--- a/tpm
+++ b/tpm
@@ -2,6 +2,7 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BINDINGS_DIR="$CURRENT_DIR/bindings"
+BINDINGS_DIR=${BINDINGS_DIR// /\\ } 
 SCRIPTS_DIR="$CURRENT_DIR/scripts"
 
 source "$SCRIPTS_DIR/variables.sh"


### PR DESCRIPTION
if you user directory have spaces tpm will not work and return 127 this is the fix for it 