### PR TITLE
Update `docs/automatic_tpm_installation.md`

### DIFF
--- a/docs/automatic_tpm_installation.md
+++ b/docs/automatic_tpm_installation.md
@@ -5,8 +5,11 @@ One of the first things we do on a new machine is cloning our dotfiles. Not ever
 If you want to install `tpm` and plugins automatically when tmux is started, put the following snippet in `.tmux.conf` before the final `run '~/.tmux/plugins/tpm/tpm'`:
 
 ```
-if "test ! -d ~/.tmux/plugins/tpm" \
-   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+if "test ! -d ~/.tmux/plugins/tpm" {
+  run "mkdir -p ~/.tmux/plugins"
+  run "git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm"
+  run "~/.tmux/plugins/tpm/bin/install_plugins"
+}
 ```
 
-This useful tip was submitted by @acr4 and narfman0.
+This useful tip was submitted by acr4, narfman0 and pacifi5t.


### PR DESCRIPTION
Hi there!

I was creating my own tmux config recently and added a snippet to install tpm automatically if it's not installed yet. But I think it's a bit overcomplicated, and tmux manual mentions using braces:

```man
Braces are parsed as a configuration file (so conditions such as ‘%if’ are processed)
and then converted into a string.  They are designed to avoid the need for additional
escaping  when  passing  a  group  of  tmux  commands  as an argument (for example to
if-shell).  These two examples produce an identical command - note that  no  escaping
is needed when using {}:

      if-shell true {
           display -p 'brace-dollar-foo: }$foo'
      }
      
      if-shell true "display -p 'brace-dollar-foo: }\$foo'"
```

So, I replaced the snippet in the docs:

```
if "test ! -d ~/.tmux/plugins/tpm" \
   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
```

with this one:

```
if "test ! -d ~/.tmux/plugins/tpm" {
  run "mkdir -p ~/.tmux/plugins"
  run "git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm"
  run "~/.tmux/plugins/tpm/bin/install_plugins"
}
```

I tried it on a bunch of machines, and it works, so I guess I should share this.