### PR TITLE
Add branches support to update_plugin.sh

### DIFF
--- a/scripts/update_plugin.sh
+++ b/scripts/update_plugin.sh
@@ -19,15 +19,52 @@ shift
 
 pull_changes() {
 	local plugin="$1"
+	local branch="$2"
 	local plugin_path="$(plugin_path_helper "$plugin")"
-	cd "$plugin_path" &&
-		GIT_TERMINAL_PROMPT=0 git pull &&
-		GIT_TERMINAL_PROMPT=0 git submodule update --init --recursive
+	(
+		set -e
+
+		cd "$plugin_path"
+		export GIT_TERMINAL_PROMPT=0
+
+		if [ -n "$branch" ]
+		then
+			# Since `clone()` in *install_plugins.sh* uses `--single-branch`, the
+			# `remote.origin.fetch` is set to `+refs/tags/<BRANCH>:refs/tags/<BRANCH>`.
+			# Thus, no other branch could be used, but only the one that was used
+			# during the `clone()`.
+			#
+			# The following `git config` allows to use other branches that are
+			# available on remote.
+			git config remote.origin.fetch "+refs/heads/*:refs/tags/*"
+			# Fetch recent branches/tags/commits.
+			# `--tags` ensures that tags from the remote are fetched.
+			# `--force` ensures that updated tags do not cause errors during fetch.
+			git fetch --force --tags
+			# `checkout` should be used after `fetch`.
+			git checkout "$branch"
+			# `merge` can only be used when HEAD points to a branch.
+			if git show-ref --quiet --branches "$branch"
+			then
+				git merge --ff-only
+			fi
+		else
+			# User might remove `#branch` suffix from config. In this case the
+			# default origin branch should be set.
+			local default_branch="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+			git remote set-branches --add origin "$default_branch"
+			git fetch --force --tags
+			git checkout "$default_branch"
+			git merge --ff-only
+		fi
+		git submodule update --init --recursive
+	)
 }
 
 update() {
 	local plugin="$1" output
-	output=$(pull_changes "$plugin" 2>&1)
+	local branch="$2"
+	output=$(pull_changes "$plugin" "$branch" 2>&1)
 	if (( $? == 0 )); then
 		echo_ok "  \"$plugin\" update success"
 		echo_ok "$(echo "$output" | sed -e 's/^/    | /')"
@@ -44,9 +81,10 @@ update_all() {
 	for plugin in $plugins; do
 		IFS='#' read -ra plugin <<< "$plugin"
 		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
+		local branch="${plugin[1]}"
 		# updating only installed plugins
 		if plugin_already_installed "$plugin_name"; then
-			update "$plugin_name" &
+			update "$plugin_name" "$branch" &
 		fi
 	done
 	wait
@@ -57,8 +95,9 @@ update_plugins() {
 	for plugin in $plugins; do
 		IFS='#' read -ra plugin <<< "$plugin"
 		local plugin_name="$(plugin_name_helper "${plugin[0]}")"
+		local branch="${plugin[1]}"
 		if plugin_already_installed "$plugin_name"; then
-			update "$plugin_name" &
+			update "$plugin_name" "$branch" &
 		else
 			echo_err "$plugin_name not installed!" &
 		fi


### PR DESCRIPTION
# Encountered problem

Recently I've encountered an issue with [https://github.com/catppuccin/tmux/tree/main](catppuccin) plugin. The most recent release was not backwards compatible (major version update), and because of that my config was no longer working, although I was happy with how it had looked like.

The **catppuccin** plugin was added to my *tmux.conf* like this:

```bash
set-option -g @plugin 'catppuccin/tmux'
```

Since there was no tag specified like `'catppuccin/tmux#v0.3'`, the `update_plugins all` fetches the most recent version from `origin/HEAD` -- which is to be expected. What I hadn't expected, was that when I had fixed my config by adding the tag:

```bash
set-option -g @plugin 'catppuccin/tmux#v0.3'
```

restarted `tmux`, and run `update_plugins all` again, the `catppuccin/tmux` repository still had the `main` branch (the one that was configured with `origin/HEAD`) checked out. Only when I had removed the plugin entirely and then brought it back with the appropriate version, the problem was solved.

When user changes the version in the config it is not used by the `update_plugins`. It means that in order to change the version, the user has to remove the plugin entirely and then reinstall it.

# Cause

The issue was that *scripts/update_plugin.sh* ignores branches/tags/commits set in the config.

# Fix

I have fixed the described issue in this PR. Could you please kindly take a look? Any suggestions and comments are highly appreciated.

I haven't contributed to the `tpm` project yet, so I understand that the changes that I've made might not follow the used coding style (although, I did my best to make sure they do). In case you find the code style to be incompatible, please kindly let me know.