### PR TITLE
Fix vi mode continue key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### master
+- bug: when using `vi` copy mode, Enter does not quit screen after tpm
+  installation/update. Fix by making `q` the key for vi mode.
 
 ### v3.1.0, 2023-01-03
 - upgrade to new version of `tmux-test`

--- a/scripts/helpers/tmux_echo_functions.sh
+++ b/scripts/helpers/tmux_echo_functions.sh
@@ -19,7 +19,7 @@ end_message() {
 	if _has_emacs_mode_keys; then
 		local continue_key="ESCAPE"
 	else
-		local continue_key="ENTER"
+		local continue_key="q"
 	fi
 	tmux_echo ""
 	tmux_echo "TMUX environment reloaded."


### PR DESCRIPTION
Fix vi mode continue key

Since tmux v2.4 the `Enter` key default is `"send -X copy-selection-and-cancel"`
and `q` is `"send -X cancel"` in copy-mode-vi