### PR TITLE
Fix to show output from installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### master
+- bug: in `bindings\install_plugins` when using `>/dev/null 2>&1` no output on screen. Fix delete the command.
 
 ### v3.1.0, 2023-01-03
 - upgrade to new version of `tmux-test`

--- a/bindings/install_plugins
+++ b/bindings/install_plugins
@@ -12,7 +12,7 @@ source "$HELPERS_DIR/tmux_utils.sh"
 
 main() {
 	reload_tmux_environment
-	"$SCRIPTS_DIR/install_plugins.sh" --tmux-echo >/dev/null 2>&1
+	"$SCRIPTS_DIR/install_plugins.sh" --tmux-echo
 	reload_tmux_environment
 	end_message
 }


### PR DESCRIPTION
Fix to show output from installation script

`>/dev/null 2>&1`

- `>/dev/null ` redirect all output to ` /dev/null `
- only redirect stderr `2>` to `&1` stdout from script.
