### PR TITLE
Change location of verify_tpm_path_permissions function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### master
+- change location of `verify_tpm_path_permissions` function from `scripts/install_plugins.sh` to `scripts/helper/utility.sh`.
+  Reason: it is a helper funcction, not a install function.
 
 ### v3.1.0, 2023-01-03
 - upgrade to new version of `tmux-test`

--- a/scripts/helpers/utility.sh
+++ b/scripts/helpers/utility.sh
@@ -2,6 +2,14 @@ ensure_tpm_path_exists() {
 	mkdir -p "$(tpm_path)"
 }
 
+verify_tpm_path_permissions() {
+	local path="$(tpm_path)"
+	# check the write permission flag for all users to ensure
+	# that we have proper access
+	[ -w "$path" ] ||
+		echo_err "$path is not writable!"
+}
+
 fail_helper() {
 	local message="$1"
 	echo "$message" >&2

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -58,14 +58,6 @@ install_plugins() {
 	done
 }
 
-verify_tpm_path_permissions() {
-	local path="$(tpm_path)"
-	# check the write permission flag for all users to ensure
-	# that we have proper access
-	[ -w "$path" ] ||
-		echo_err "$path is not writable!"
-}
-
 main() {
 	ensure_tpm_path_exists
 	verify_tpm_path_permissions


### PR DESCRIPTION
Change location of `verify_tpm_path_permissions` function from `scripts/install_plugins.sh` to `scripts/helper/utility.sh`.


Reason:
- It is a helper funcction, not a install function.