### PR TITLE
Fix clean function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### master
+- bug: fix the `clean_plugins` function and delete too many slashes, `TMUX_PLUGIN_MANAGER_PATH` default is set to `/` at the path end.
 
 ### v3.1.0, 2023-01-03
 - upgrade to new version of `tmux-test`

--- a/scripts/clean_plugins.sh
+++ b/scripts/clean_plugins.sh
@@ -16,7 +16,7 @@ clean_plugins() {
 	local plugins plugin plugin_directory
 	plugins="$(tpm_plugins_list_helper)"
 
-	for plugin_directory in "$(tpm_path)"/*; do
+	for plugin_directory in "$(tpm_path)"*; do
 		[ -d "${plugin_directory}" ] || continue
 		plugin="$(plugin_name_helper "${plugin_directory}")"
 		case "${plugins}" in

--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -9,7 +9,7 @@ _manual_expansion() {
 }
 
 _tpm_path() {
-	local string_path="$(tmux start-server\; show-environment -g TMUX_PLUGIN_MANAGER_PATH | cut -f2 -d=)/"
+	local string_path="$(tmux start-server\; show-environment -g TMUX_PLUGIN_MANAGER_PATH | cut -f2 -d=)"
 	_manual_expansion "$string_path"
 }
 
@@ -26,7 +26,6 @@ _get_user_tmux_conf() {
 	# Search for the correct configuration file by priority.
 	if [ -f "$xdg_location" ]; then
 		echo "$xdg_location"
-
 	else
 		echo "$default_location"
 	fi


### PR DESCRIPTION
Fix the `clean_plugins` function and delete too many slashes, `TMUX_PLUGIN_MANAGER_PATH` default is set to `/` at the path end.