### PR TITLE
Adding optional alias to plugin definitions for git clone operations

### DIFF
--- a/scripts/helpers/plugin_functions.sh
+++ b/scripts/helpers/plugin_functions.sh
@@ -81,9 +81,13 @@ tpm_plugins_list_helper() {
 # 1. "git://github.com/user/plugin_name.git"
 # 2. "user/plugin_name"
 plugin_name_helper() {
-	local plugin="$1"
+	local plugin="${1%%;*}"
+	local alias=$(echo $1 | sed -E 's/.*alias[[:space:]]*[:=][[:space:]]*//')
+
+  [[ "$alias" == "$1" ]] && alias=""
+
 	# get only the part after the last slash, e.g. "plugin_name.git"
-	local plugin_basename="$(basename "$plugin")"
+	local plugin_basename=$([[ -n "$alias" ]] && echo "$alias" || basename "$plugin")
 	# remove ".git" extension (if it exists) to get only "plugin_name"
 	local plugin_name="${plugin_basename%.git}"
 	echo "$plugin_name"

--- a/scripts/install_plugins.sh
+++ b/scripts/install_plugins.sh
@@ -39,11 +39,11 @@ clone_plugin() {
 # clone plugin and produce output
 install_plugin() {
 	local plugin="${1%%;*}"
-	local alias=$(echo $1 | sed -E 's/.*alias[[:space:]]*[:=][[:space:]]*//')
-	local branch="$2"
+	local alias=$(echo $1$2 | sed -E 's/.*alias[[:space:]]*[:=][[:space:]]*//')
+	local branch="${2%%;*}"
 	local plugin_name="$(plugin_name_helper "$plugin")"
 
-  [[ "$alias" == "$1" ]] && alias=""
+  [[ "$alias" == "$1$2" ]] && alias=""
 
 	if plugin_already_installed "$plugin"; then
 		echo_ok "Already installed \"$plugin_name\""

--- a/scripts/source_plugins.sh
+++ b/scripts/source_plugins.sh
@@ -31,7 +31,7 @@ source_plugins() {
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
 		IFS='#' read -ra plugin <<< "$plugin"
-		plugin_path="$(plugin_path_helper "${plugin[0]%%;*}")"
+		plugin_path="$(plugin_path_helper "${plugin[0]}")"
 		silently_source_all_tmux_files "$plugin_path"
 	done
 }

--- a/scripts/source_plugins.sh
+++ b/scripts/source_plugins.sh
@@ -31,7 +31,7 @@ source_plugins() {
 	local plugins="$(tpm_plugins_list_helper)"
 	for plugin in $plugins; do
 		IFS='#' read -ra plugin <<< "$plugin"
-		plugin_path="$(plugin_path_helper "${plugin[0]}")"
+		plugin_path="$(plugin_path_helper "${plugin[0]%%;*}")"
 		silently_source_all_tmux_files "$plugin_path"
 	done
 }


### PR DESCRIPTION
**Rationale**
When two plugins are defined using a similar name, they will be cloned to the same location effectively overriding the plugin contents.

**How this works**
Adding an optional alias suffix to plugin definition to use it in git clone as output directory.
This is specially useful in case of conflicting plugins (i.e. same name) , for example, dracula/tmux, catppuccin/tmux.

```tmux
set -g @plugin '<plugin>;alias=<alias>'
```

Using this feature we can define an alias like : 
```tmux
 set -g @plugin 'dracula/tmux;alias=dracula'
 set -g @plugin 'catppuccin/tmux;alias=catppuccin'
```
this will effectively clone both plugins using the optional alias provided.