### PR TITLE
Update automatic TPM installation instructions

### DIFF
--- a/docs/automatic_tpm_installation.md
+++ b/docs/automatic_tpm_installation.md
@@ -5,6 +5,8 @@ One of the first things we do on a new machine is cloning our dotfiles. Not ever
 If you want to install `tpm` and plugins automatically when tmux is started, put the following snippet in `.tmux.conf` before the final `run '~/.tmux/plugins/tpm/tpm'`:
 
 ```
+setenv -g TMUX_PLUGIN_MANAGER_PATH '~/.tmux/plugins/'
+
 if "test ! -d ~/.tmux/plugins/tpm" \
    "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 ```


### PR DESCRIPTION
install_plugin is looking for an environmental variable `TMUX_PLUGIN_MANAGER_PATH` that is only available after initialization of tpm.

Closes #105